### PR TITLE
Write svelte Files w/ Initial Round of Adaptors

### DIFF
--- a/src/lib/aave_v3_a_token.svelte
+++ b/src/lib/aave_v3_a_token.svelte
@@ -1,0 +1,87 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+    export let token = "";
+    export let amount = "";
+    export let asset = "";
+    export let use_as_collateral = false;
+    export let category_id = 0;
+
+    /// async functions communicating with protos
+    
+    async function scheduleDeposit() {
+        const result = await invoke("DepositToAave", { token, amount });
+        console.log(result);
+    }
+
+    async function scheduleWithdraw() {
+        const result = await invoke("WithdrawFromAave", { token, amount });
+        console.log(result);
+    }
+
+    async function AdjustIsolationModeAssetAsCollateral() {
+        const result = await invoke("AdjustIsolationModeAssetAsCollateral", { asset, use_as_collateral });
+        console.log(result);
+    }
+
+    async function ChangeEMode() {
+        const result = await invoke("ChangeEMode", { category_id});
+        console.log(result);
+    }
+</script>
+
+<!-- Aave V3 Deposit -->
+
+<h1>1. Aave V3 Deposit</h1>
+<div>
+    <label for="token" title="Enter the ERC-20 token contract address as a string.">ERC-20 Token Contract Address:</label>
+    <input type="text" id="token" bind:value={token} placeholder="0xtoken" />
+</div>
+<div>
+    <label for="amount" title="Enter the amount of the ERC-20 asset to deposit as a string.">Amount of ERC-20 Asset:</label>
+    <input type="text" id="amount" bind:value={amount} placeholder="Amount" />
+</div>
+<button on:click={scheduleDeposit}>Deposit</button>
+
+<!-- Aave V3 Withdraw -->
+
+<h1>2. Aave V3 Withdraw</h1>
+<div>
+    <label for="token" title="Enter the ERC-20 token contract address as a string.">ERC-20 Token Contract Address:</label>
+    <input type="text" id="token" bind:value={token} placeholder="0xtoken" />
+</div>
+<div>
+    <label for="amount" title="Enter the amount of the ERC-20 asset to withdraw as a string.">Amount of ERC-20 Asset:</label>
+    <input type="text" id="amount" bind:value={amount} placeholder="Amount" />
+</div>
+<button on:click={scheduleWithdraw}>Withdraw</button>
+
+<!-- Adjust Isolation Mode Asset As Collateral -->
+
+<h1>3. Adjust Isolation Mode Asset As Collateral</h1>
+<div>
+    <label for="asset" title="Enter the ERC-20 token contract address as a string.">ERC-20 Token Contract Address:</label>
+    <input type="text" id="asset" bind:value={asset} placeholder="0xtoken" />
+</div>
+<div>
+    <label for="use_as_collateral" title="Whether to use the asset as collateral.">Use as Collateral:</label>
+    <input type="boolean" id="amount" bind:value={use_as_collateral} placeholder="false" />
+</div>
+<button on:click={AdjustIsolationModeAssetAsCollateral}>Adjust Isolation Mode Asset As Collateral</button>
+
+<!-- Change EMode -->
+
+<h1>4. Change EMode</h1>
+<div>
+    <label for="category_id" title="Enter the categoryId as a uint32">Category ID:</label>
+    <input type="uint32" id="category_id" bind:value={category_id} placeholder=0 />
+</div>
+<button on:click={ChangeEMode}>ChangeEMode</button>
+
+<!-- Additional text information at the bottom of the page -->
+<div>
+    <h2>Specific Strategist Information</h2>
+    <p>A. Keep in mind regarding isolated markets. If they are isolated, then they may not be usable as collateral for other borrow positions.</p>
+    <p>B. See the <a href="https://sommelier-finance.gitbook.io/sommelier-documentation/smart-contracts/protocol-v2-contract-architecture">docs</a> for more information pertaining to this adaptor.</p>
+    <!-- Empty lines of spaces -->
+    <br /><br /><br />
+</div>

--- a/src/lib/aave_v3_debt.svelte
+++ b/src/lib/aave_v3_debt.svelte
@@ -1,0 +1,71 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+    export let token = "";
+    export let amount = "";
+    export let underlying_token = "";
+
+    /// async functions communicating with protos
+    
+    async function scheduleBorrow() {
+        const result = await invoke("BorrowFromAave", { token, amount });
+        console.log(result);
+    }
+
+    async function scheduleRepayDebt() {
+        const result = await invoke("RepayAaveDebt", { token, amount });
+        console.log(result);
+    }
+
+    async function scheduleRepayWithATokens() {
+        const result = await invoke("RepayWithATokens", { underlying_token, amount });
+        console.log(result);
+    }
+</script>
+
+<!-- Aave V3 Deposit -->
+
+<h1>1. Aave V3 Borrow</h1>
+<div>
+    <label for="token" title="Enter the ERC-20 token contract address as a string.">ERC-20 Token Contract Address:</label>
+    <input type="text" id="token" bind:value={token} placeholder="0xtoken" />
+</div>
+<div>
+    <label for="amount" title="Enter the amount of the ERC-20 asset to borrow as a string.">Amount of ERC-20 Asset:</label>
+    <input type="text" id="amount" bind:value={amount} placeholder="Amount" />
+</div>
+<button on:click={scheduleBorrow}>Borrow</button>
+
+<!-- Aave V3 Withdraw -->
+
+<h1>2. Repay Debt with Underlying</h1>
+<div>
+    <label for="token" title="Enter the ERC-20 token contract address as a string.">ERC-20 Token Contract Address:</label>
+    <input type="text" id="token" bind:value={token} placeholder="0xtoken" />
+</div>
+<div>
+    <label for="amount" title="Enter the amount of the ERC-20 asset to repay as a string.">Amount of ERC-20 Asset:</label>
+    <input type="text" id="amount" bind:value={amount} placeholder="Amount" />
+</div>
+<button on:click={scheduleRepayDebt}>Repay Debt with Underlying</button>
+
+<!-- Repay Debt with AToken -->
+
+<h1>3. Repay Debt with AToken</h1>
+<div>
+    <label for="underlying_token" title="Enter the ERC-20 token contract address as a string.">ERC-20 Token Contract Address:</label>
+    <input type="text" id="underlying_token" bind:value={underlying_token} placeholder="0xtoken" />
+</div>
+<div>
+    <label for="amount" title="Enter the amount of the ERC-20 asset to repay as a string.">Amount of AToken to Repay:</label>
+    <input type="text" id="amount" bind:value={amount} placeholder="Amount" />
+</div>
+<button on:click={scheduleRepayWithATokens}>Repay Debt with AToken</button>
+
+<!-- Additional text information at the bottom of the page -->
+<div>
+    <h2>Specific Strategist Information</h2>
+    <p>A. Keep in mind regarding isolated markets. If they are isolated, then they may not be usable as collateral for other borrow positions.</p>
+    <p>B. See the <a href="https://sommelier-finance.gitbook.io/sommelier-documentation/smart-contracts/protocol-v2-contract-architecture">docs</a> for more information pertaining to this adaptor.</p>
+    <!-- Empty lines of spaces -->
+    <br /><br /><br />
+</div>

--- a/src/lib/aura_erc4626.svelte
+++ b/src/lib/aura_erc4626.svelte
@@ -1,0 +1,34 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+  
+    let auraPool = "";
+    let claimExtras = false;
+  
+    async function getRewards() {
+      try {
+        const result = await invoke("getRewards", {
+          aura_pool: auraPool,
+          claim_extras: claimExtras
+        });
+        console.log("GetRewards result:", result);
+      } catch (error) {
+        console.error("Error invoking getRewards:", error);
+      }
+    }
+  </script>
+  
+  <form on:submit|preventDefault={getRewards}>
+    <h2>Get Rewards from Aura Pool</h2>
+    <div>
+      <label for="auraPool" title="TODO - PLACEHOLDER">Aura Pool Address:</label>
+      <input type="text" id="auraPool" bind:value={auraPool} placeholder="Enter Aura Pool Address">
+    </div>
+    <div>
+      <label for="claimExtras" title="TODO - PLACEHOLDER">
+        <input type="checkbox" id="claimExtras" bind:checked={claimExtras}>
+        Claim Extra Rewards
+      </label>
+    </div>
+    <button type="submit">Get Rewards</button>
+  </form>
+  

--- a/src/lib/balancer_pool.svelte
+++ b/src/lib/balancer_pool.svelte
@@ -1,0 +1,184 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+  
+    // Variables for SingleSwap
+    let pool_id = "";
+    let kind = ""; // This would be an enum in the actual implementation
+    let asset_in = "";
+    let asset_out = "";
+    let amount = "";
+    let user_data = ""; // This needs to be handled as bytes
+  
+    // Variables for SwapData
+    let min_amounts_for_swaps = []; // This would be an array of strings
+    let swap_deadlines = []; // This would be an array of strings
+  
+    // Variables for JoinPool
+    let target_bpt = "";
+    let swaps_before_join = []; // This would require a complex input method for multiple SingleSwaps
+    let swap_data = {}; // This would be the input for SwapData
+    let minimum_bpt = "";
+  
+    // Variables for ExitPoolRequest
+    let assets = []; // Array of strings
+    let min_amounts_out = []; // Array of strings
+    let exit_user_data = ""; // As bytes
+    let to_internal_balance = false;
+  
+    // Variables for ExitPool
+    let exit_target_bpt = "";
+    let swaps_after_exit = []; // Complex input for multiple SingleSwaps
+    let exit_swap_data = {}; // Input for SwapData
+    let request = {}; // Input for ExitPoolRequest
+  
+    // Variables for StakeBPT
+    let bpt = "";
+    let liquidity_gauge = "";
+    let amount_in = "";
+  
+    // Variables for UnstakeBPT
+    let unstake_bpt = "";
+    let unstake_liquidity_gauge = "";
+    let amount_out = "";
+  
+    // Variables for ClaimRewards
+    let gauge = "";
+  
+    // Async functions for invoking the respective operations
+    async function performSingleSwap() {
+      const result = await invoke("SingleSwap", { pool_id, kind, asset_in, asset_out, amount, user_data });
+      console.log(result);
+    }
+  
+    async function performSwapData() {
+      const result = await invoke("SwapData", { min_amounts_for_swaps, swap_deadlines });
+      console.log(result);
+    }
+  
+    async function performJoinPool() {
+      const result = await invoke("JoinPool", { target_bpt, swaps_before_join, swap_data, minimum_bpt });
+      console.log(result);
+    }
+  
+    async function performExitPoolRequest() {
+      const result = await invoke("ExitPoolRequest", { assets, min_amounts_out, exit_user_data, to_internal_balance });
+      console.log(result);
+    }
+  
+    async function performExitPool() {
+      const result = await invoke("ExitPool", { exit_target_bpt, swaps_after_exit, exit_swap_data, request });
+      console.log(result);
+    }
+  
+    async function performStakeBPT() {
+      const result = await invoke("StakeBPT", { bpt, liquidity_gauge, amount_in });
+      console.log(result);
+    }
+  
+    async function performUnstakeBPT() {
+      const result = await invoke("UnstakeBPT", { unstake_bpt, unstake_liquidity_gauge, amount_out });
+      console.log(result);
+    }
+  
+    async function performClaimRewards() {
+      const result = await invoke("ClaimRewards", { gauge });
+      console.log(result);
+    }
+  </script>
+  
+  <!-- UI Components for Each Message Type -->
+  <!-- Due to the complexity and the large number of fields, only a representative sample is provided for SingleSwap and JoinPool TODO - FINISH SINGLESWAP-->
+  
+  <h1>Perform SingleSwap</h1>
+  <div>
+      <label for="pool_id" title="TODO - PLACEHOLDER">Pool ID:</label>
+      <input type="text" id="pool_id" bind:value={pool_id} placeholder="Enter Pool ID">
+  </div>
+  <div>
+      <label for="kind" title="TODO - PLACEHOLDER">Swap Kind:</label>
+      <select id="kind" bind:value={kind}>
+          <option value="">Select Kind</option>
+          <!-- Populate options here based on enum values -->
+      </select>
+  </div>
+  <!-- Continue with other fields for SingleSwap -->
+  <button on:click={performSingleSwap}>Perform Swap</button>
+  
+  <h1>Join Pool</h1>
+  <div>
+      <label for="target_bpt" title="TODO - PLACEHOLDER">Target BPT:</label>
+      <input type="text" id="target_bpt" bind:value={target_bpt} placeholder="Enter Target BPT">
+  </div>
+  <!-- Inputs for swaps_before_join would need a more complex UI component, possibly a list of SingleSwap components -->
+  <!-- Continue with other fields for JoinPool TODO - FINISH OFF THIS-->
+  <button on:click={performJoinPool}>Join Pool</button>
+  
+  <!-- ExitPoolRequest UI -->
+<h1>Exit Pool Request</h1>
+<div>
+    <label for="assets" title="TODO - PLACEHOLDER">Assets:</label>
+    <input type="text" id="assets" bind:value={assets} placeholder="Asset Addresses, comma-separated">
+</div>
+<div>
+    <label for="min_amounts_out" title="TODO - PLACEHOLDER">Minimum Amounts Out:</label>
+    <input type="text" id="min_amounts_out" bind:value={min_amounts_out} placeholder="Minimum Amounts, comma-separated">
+</div>
+<div>
+    <label for="exit_user_data" title="TODO - PLACEHOLDER">User Data:</label>
+    <input type="text" id="exit_user_data" bind:value={exit_user_data} placeholder="User Data in bytes">
+</div>
+<div>
+    <label for="to_internal_balance" title="TODO - PLACEHOLDER">To Internal Balance:</label>
+    <input type="checkbox" id="to_internal_balance" bind:checked={to_internal_balance}>
+</div>
+<button on:click={performExitPoolRequest}>Submit Exit Pool Request</button>
+
+<!-- ExitPool UI -->
+<h1>Exit Pool</h1>
+<div>
+    <label for="exit_target_bpt" title="TODO - PLACEHOLDER">Target BPT:</label>
+    <input type="text" id="exit_target_bpt" bind:value={exit_target_bpt} placeholder="Enter Target BPT">
+</div>
+<!-- Inputs for swaps_after_exit would need a dynamic UI component for multiple SingleSwaps -->
+<button on:click={performExitPool}>Exit Pool</button>
+
+<!-- StakeBPT UI -->
+<h1>Stake BPT</h1>
+<div>
+    <label for="bpt" title="TODO - PLACEHOLDER">BPT:</label>
+    <input type="text" id="bpt" bind:value={bpt} placeholder="BPT Address">
+</div>
+<div>
+    <label for="liquidity_gauge" title="TODO - PLACEHOLDER">Liquidity Gauge:</label>
+    <input type="text" id="liquidity_gauge" bind:value={liquidity_gauge} placeholder="Liquidity Gauge Address">
+</div>
+<div>
+    <label for="amount_in" title="TODO - PLACEHOLDER">Amount:</label>
+    <input type="text" id="amount_in" bind:value={amount_in} placeholder="Amount to Stake">
+</div>
+<button on:click={performStakeBPT}>Stake BPT</button>
+
+<!-- UnstakeBPT UI -->
+<h1>Unstake BPT</h1>
+<div>
+    <label for="unstake_bpt" title="TODO - PLACEHOLDER">BPT:</label>
+    <input type="text" id="unstake_bpt" bind:value={unstake_bpt} placeholder="BPT Address">
+</div>
+<div>
+    <label for="unstake_liquidity_gauge" title="TODO - PLACEHOLDER">Liquidity Gauge:</label>
+    <input type="text" id="unstake_liquidity_gauge" bind:value={unstake_liquidity_gauge} placeholder="Liquidity Gauge Address">
+</div>
+<div>
+    <label for="amount_out title="TODO - PLACEHOLDER"">Amount:</label>
+    <input type="text" id="amount_out" bind:value={amount_out} placeholder="Amount to Unstake">
+</div>
+<button on:click={performUnstakeBPT}>Unstake BPT</button>
+
+<!-- ClaimRewards UI -->
+<h1>Claim Rewards</h1>
+<div>
+    <label for="gauge" title="TODO - PLACEHOLDER">Gauge:</label>
+    <input type="text" id="gauge" bind:value={gauge} placeholder="Gauge Address">
+</div>
+<button on:click={performClaimRewards}>Claim Rewards</button>
+  

--- a/src/lib/convexCurve.svelte
+++ b/src/lib/convexCurve.svelte
@@ -1,0 +1,70 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+    
+    // Variables for DepositLPTInConvexAndStake
+    export let pid = "";
+    export let baseRewardPool = "";
+    export let lpt = "";
+    export let pool = "";
+    export let selector = "";
+    export let amountToDeposit = "";
+    
+    // Variables for WithdrawFromBaseRewardPoolAsLPT
+    export let amountToWithdraw = "";
+    export let claim = false;
+    
+    // Variables for GetRewards
+    export let claimExtras = false;
+    
+    // Function to deposit and stake LPTs into Convex
+    async function depositLPTInConvexAndStake() {
+        const result = await invoke("depositLPTInConvexAndStake", { pid, base_reward_pool: baseRewardPool, lpt, pool, selector, amount_to_deposit: amountToDeposit });
+        console.log(result);
+    }
+    
+    // Function to withdraw from Convex
+    async function withdrawFromBaseRewardPoolAsLPT() {
+        const result = await invoke("withdrawFromBaseRewardPoolAsLPT", { base_reward_pool: baseRewardPool, amount_to_withdraw: amountToWithdraw, claim });
+        console.log(result);
+    }
+    
+    // Function to get rewards from Convex
+    async function getRewards() {
+        const result = await invoke("getRewards", { base_reward_pool: baseRewardPool, claim_extras: claimExtras });
+        console.log(result);
+    }
+    </script>
+    
+    <!-- DepositLPTInConvexAndStake UI -->
+    <h1>Deposit and Stake LPT in Convex</h1>
+    <div>
+        <label for="pid" title="Enter the Pool ID (PID) as a string.">PID:</label>
+        <input type="text" id="pid" bind:value={pid} placeholder="Enter PID">
+    </div>
+    <div>
+        <label for="baseRewardPool" title="Enter the Base Reward Pool address as a string.">Base Reward Pool:</label>
+        <input type="text" id="baseRewardPool" bind:value={baseRewardPool} placeholder="Enter Base Reward Pool Address">
+    </div>
+    <!-- Include additional fields for lpt, pool, selector, and amountToDeposit -->
+    <button on:click={depositLPTInConvexAndStake}>Deposit and Stake</button>
+    
+    <!-- WithdrawFromBaseRewardPoolAsLPT UI -->
+    <h1>Withdraw from Convex</h1>
+    <div>
+        <label for="amountToWithdraw" title="Enter the amount to withdraw from ConvexCurve market, as a string.">Amount to Withdraw:</label>
+        <input type="text" id="amountToWithdraw" bind:value={amountToWithdraw} placeholder="Enter amount to withdraw">
+    </div>
+    <div>
+        <label for="claim" title="Enter whether or not to rewards associated to respective ConvexCurve market position, as a bool.">Claim Rewards:</label>
+        <input type="checkbox" id="claim" bind:checked={claim}>
+    </div>
+    <button on:click={withdrawFromBaseRewardPoolAsLPT}>Withdraw</button>
+    
+    <!-- GetRewards UI -->
+    <h1>Get Rewards from Convex</h1>
+    <div>
+        <label for="claimExtras" title="Enter whether or not to claim extra rewards in addition to baseRewards with respective ConvexCurve market, as a bool.">Claim Extras:</label>
+        <input type="checkbox" id="claimExtras" bind:checked={claimExtras}>
+    </div>
+    <button on:click={getRewards}>Get Rewards</button>
+    

--- a/src/lib/ctoken.svelte
+++ b/src/lib/ctoken.svelte
@@ -1,0 +1,53 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+    
+    // Variables
+    export let market = "";
+    export let amountToDeposit = "";
+    export let amountToWithdraw = "";
+    
+    // Async functions to communicate with the backend
+    async function depositToCompound() {
+        const result = await invoke("DepositToCompound", { market, amount_to_deposit: amountToDeposit });
+        console.log(result);
+    }
+    
+    async function withdrawFromCompound() {
+        const result = await invoke("WithdrawFromCompound", { market, amount_to_withdraw: amountToWithdraw });
+        console.log(result);
+    }
+    
+    async function claimComp() {
+        const result = await invoke("ClaimComp", {});
+        console.log(result);
+    }
+    </script>
+    
+    <!-- Compound Deposit UI -->
+    <h1>Deposit to Compound</h1>
+    <div>
+        <label for="marketDeposit" title="Enter the compound market, as a string.">Market:</label>
+        <input type="text" id="marketDeposit" bind:value={market} placeholder="Enter the Compound market address" />
+    </div>
+    <div>
+        <label for="amountToDeposit" title="Enter the amount to deposit into market, as a string.">Amount to Deposit:</label>
+        <input type="text" id="amountToDeposit" bind:value={amountToDeposit} placeholder="Enter amount to deposit" />
+    </div>
+    <button on:click={depositToCompound}>Deposit</button>
+    
+    <!-- Compound Withdraw UI -->
+    <h1>Withdraw from Compound</h1>
+    <div>
+        <label for="marketWithdraw" title="Enter the compound market, as a string.">Market:</label>
+        <input type="text" id="marketWithdraw" bind:value={market} placeholder="Enter the Compound market address" />
+    </div>
+    <div>
+        <label for="amountToWithdraw" title="Enter the amount to deposit into market, as a string.">Amount to Withdraw:</label>
+        <input type="text" id="amountToWithdraw" bind:value={amountToWithdraw} placeholder="Enter amount to withdraw" />
+    </div>
+    <button on:click={withdrawFromCompound}>Withdraw</button>
+    
+    <!-- Claim COMP UI -->
+    <h1>Claim COMP Rewards</h1>
+    <button on:click={claimComp}>Claim COMP</button>
+    

--- a/src/lib/curve.svelte
+++ b/src/lib/curve.svelte
@@ -1,0 +1,223 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+    
+    // Variables common to multiple operations
+    export let pool = "";
+    export let lpToken = "";
+    export let orderedUnderlyingTokenAmounts = "";
+    export let minLPAmount = "";
+    export let gauge = "";
+    export let selector = "";
+    export let lpTokenAmount = "";
+    export let orderedMinimumUnderlyingTokenAmountsOut = "";
+    export let useUnderlying = false;
+    export let amount = "";
+
+    let poolRL = "";
+    let lpTokenRL = "";
+    let lpTokenAmountRL = "";
+    let orderedMinimumUnderlyingTokenAmountsOutRL = ""; // Assuming a JSON string input for simplicity
+    let useUnderlyingRL = false;
+    let gaugeRL = "";
+    let selectorRL = "";
+    
+    // Functions for each operation
+    async function addLiquidity() {
+        const result = await invoke("AddLiquidity", { pool, lp_token: lpToken, ordered_underlying_token_amounts: JSON.parse(orderedUnderlyingTokenAmounts), min_lp_amount: minLPAmount, gauge, selector });
+        console.log(result);
+    }
+    
+    async function addLiquidityETH() {
+        const result = await invoke("AddLiquidityETH", { pool, lp_token: lpToken, ordered_underlying_token_amounts: JSON.parse(orderedUnderlyingTokenAmounts), min_lp_amount: minLPAmount, use_underlying: useUnderlying, gauge, selector });
+        console.log(result);
+    }
+    
+    async function removeLiquidity() {
+        const result = await invoke("RemoveLiquidity", { pool, lp_token: lpToken, lp_token_amount: lpTokenAmount, ordered_minimum_underlying_token_amounts_out: JSON.parse(orderedMinimumUnderlyingTokenAmountsOut), gauge, selector });
+        console.log(result);
+    }
+    
+    async function removeLiquidityETH() {
+        const result = await invoke("RemoveLiquidityETH", { pool, lp_token: lpToken, lp_token_amount: lpTokenAmount, ordered_minimum_underlying_token_amounts_out: JSON.parse(orderedMinimumUnderlyingTokenAmountsOut), use_underlying: useUnderlying, gauge, selector });
+        console.log(result);
+    }
+    
+    async function stakeInGauge() {
+        const result = await invoke("StakeInGauge", { lp_token: lpToken, gauge, amount, pool, selector });
+        console.log(result);
+    }
+    
+    async function unstakeFromGauge() {
+        const result = await invoke("UnstakeFromGauge", { gauge, amount });
+        console.log(result);
+    }
+    
+    async function claimRewards() {
+        const result = await invoke("ClaimRewards", { gauge });
+        console.log(result);
+    }
+    </script>
+    
+    <!-- AddLiquidity UI Component-->
+    <h2>Add Liquidity (Non-ETH)</h2>
+    <div>
+        <label for="al_pool" title="Enter the Curve Pool address as a string.">Curve Pool Address:</label>
+        <input type="text" id="al_pool" bind:value={pool} placeholder="Curve Pool Address">
+    </div>
+    <div>
+        <label for="al_lpToken" title="Enter the curve pool token address as a string.">LP Token Address:</label>
+        <input type="text" id="al_lpToken" bind:value={lpToken} placeholder="LP Token Address">
+    </div>
+    <div>
+        <label for="al_orderedUnderlyingTokenAmounts" title="Enter the minimum amount of each underlying token to receive, as an array of strings.">Ordered Underlying Token Amounts:</label>
+        <input type="text" id="al_orderedUnderlyingTokenAmounts" bind:value={orderedUnderlyingTokenAmounts} placeholder="e.g., [100, 200]">
+    </div>
+    <div>
+        <label for="al_minLPAmount" title="Enter the minimum amount of LP tokens to receive, as a string.">Min LP Amount:</label>
+        <input type="text" id="al_minLPAmount" bind:value={minLPAmount} placeholder="Min LP Amount">
+    </div>
+    <div>
+        <label for="al_gauge" title="Enter the curve gauge address as a string.">Curve Gauge Address:</label>
+        <input type="text" id="al_gauge" bind:value={gauge} placeholder="Gauge Address">
+    </div>
+    <div>
+        <label for="al_selector" title="Enter the selector as a string.">Selector:</label>
+        <input type="text" id="al_selector" bind:value={selector} placeholder="Selector">
+    </div>
+    <button on:click={addLiquidity}>Add Liquidity</button>
+
+    <!-- AddLiquidityETH UI Component -->
+    <h2>Add Liquidity with ETH</h2>
+    <div>
+        <label for="aleth_pool" title="Enter the Curve Pool address as a string.">Curve Pool Address:</label>
+        <input type="text" id="aleth_pool" bind:value={pool} placeholder="Curve Pool Address">
+    </div>
+    <div>
+        <label for="aleth_lpToken" title="Enter the Curve LP Token  address as a string.">LP Token Address:</label>
+        <input type="text" id="aleth_lpToken" bind:value={lpToken} placeholder="LP Token Address">
+    </div>
+    <div>
+        <label for="aleth_orderedUnderlyingTokenAmounts" title="Enter the minimum amount of each underlying token to receive, as an array of strings.">Ordered Underlying Token Amounts:</label>
+        <input type="text" id="aleth_orderedUnderlyingTokenAmounts" bind:value={orderedUnderlyingTokenAmounts} placeholder="e.g., [100, 200]">
+    </div>
+    <div>
+        <label for="aleth_minLPAmount" title="Enter the minimum amount of LP tokens to receive, as a string.">Min LP Amount:</label>
+        <input type="text" id="aleth_minLPAmount" bind:value={minLPAmount} placeholder="Min LP Amount">
+    </div>
+    <div>
+        <label for="aleth_useUnderlying" title="Enter a bool for whether to use the underlying asset or the wrapped asset.">Use Underlying:</label>
+        <input type="checkbox" id="aleth_useUnderlying" bind:checked={useUnderlying}>
+    </div>
+    <div>
+        <label for="aleth_gauge" title="Enter the respective curve gauge address as a string.">Curve Gauge Address:</label>
+        <input type="text" id="aleth_gauge" bind:value={gauge} placeholder="Gauge Address">
+    </div>
+    <div>
+        <label for="aleth_selector" title="Enter the selector as a string.">Selector:</label>
+        <input type="text" id="aleth_selector" bind:value={selector} placeholder="Selector">
+    </div>
+    <button on:click={addLiquidityETH}>Add Liquidity with ETH</button>
+
+    <!-- RemoveLiquidity UI Component -->
+    <h2>Remove Liquidity (Non-ETH)</h2>
+    <div>
+        <label for="rl_pool" title="Enter the Curve Pool address as a string.">Curve Pool Address:</label>
+        <input type="text" id="rl_pool" bind:value={pool} placeholder="Enter Curve Pool Address">
+    </div>
+    <div>
+        <label for="rl_lpToken" title="Enter the curve pool token address as a string.">LP Token Address:</label>
+        <input type="text" id="rl_lpToken" bind:value={lpToken} placeholder="Enter LP Token Address">
+    </div>
+    <div>
+        <label for="rl_lpTokenAmount" title="Enter the Base Reward Pool address as a string.">LP Token Amount:</label>
+        <input type="text" id="rl_lpTokenAmount" bind:value={lpTokenAmount} placeholder="Enter LP Token Amount to Remove">
+    </div>
+    <div>
+        <label for="rl_orderedMinimumUnderlyingTokenAmountsOut" title="Enter the minimum amount of each underlying token to receive, as an array of strings.">Ordered Minimum Token Amounts Out:</label>
+        <input type="text" id="rl_orderedMinimumUnderlyingTokenAmountsOut" bind:value={orderedMinimumUnderlyingTokenAmountsOut} placeholder="e.g., [50, 100]">
+    </div>
+    <div>
+        <label for="rl_gauge" title="Enter the curve gauge address as a string.">Curve Gauge Address:</label>
+        <input type="text" id="rl_gauge" bind:value={gauge} placeholder="Enter Gauge Address">
+    </div>
+    <div>
+        <label for="rl_selector" title="Enter the selector as a string.">Function Selector:</label>
+        <input type="text" id="rl_selector" bind:value={selector} placeholder="Enter Selector">
+    </div>
+    <button on:click={removeLiquidity}>Remove Liquidity</button>
+
+    <!-- RemoveLiquidityETH UI Component -->
+    <h2>Remove Liquidity with ETH</h2>
+    <div>
+        <label for="rleth_useUnderlying" title="Enter bool indicating whether or not to add a true bool to the end of abi.encoded `removeLiquidity` call.">Use Underlying:</label>
+        <input type="checkbox" id="rleth_useUnderlying" bind:checked={useUnderlying}>
+    </div>
+    <div>
+        <label for="poolRL">Curve Pool Address:</label>
+        <input type="text" id="poolRL" bind:value={poolRL} placeholder="Enter Curve Pool Address">
+    </div>
+    <div>
+        <label for="lpTokenRL">LP Token Address:</label>
+        <input type="text" id="lpTokenRL" bind:value={lpTokenRL} placeholder="Enter LP Token Address">
+    </div>
+    <div>
+        <label for="lpTokenAmountRL">LP Token Amount:</label>
+        <input type="text" id="lpTokenAmountRL" bind:value={lpTokenAmountRL} placeholder="Enter LP Token Amount to Remove">
+    </div>
+    <div>
+        <label for="orderedMinimumUnderlyingTokenAmountsOutRL">Minimum Underlying Token Amounts Out:</label>
+        <input type="text" id="orderedMinimumUnderlyingTokenAmountsOutRL" bind:value={orderedMinimumUnderlyingTokenAmountsOutRL} placeholder="Enter JSON array of min amounts out">
+    </div>
+    <div>
+        <label for="gaugeRL">Curve Gauge Address:</label>
+        <input type="text" id="gaugeRL" bind:value={gaugeRL} placeholder="Enter Gauge Address">
+    </div>
+    <div>
+        <label for="selectorRL">Function Selector:</label>
+        <input type="text" id="selectorRL" bind:value={selectorRL} placeholder="Enter Function Selector">
+    </div>
+    <button on:click={removeLiquidityETH}>Remove Liquidity with ETH</button>
+
+    <!-- StakeInGauge UI Component -->
+    <h2>Stake In Gauge</h2>
+    <div>
+        <label for="sig_lpToken" title="Enter the address of the LP token as a string.">LP Token Address:</label>
+        <input type="text" id="sig_lpToken" bind:value={lpToken} placeholder="Enter LP Token Address">
+    </div>
+    <div>
+        <label for="sig_gauge" title="Enter the Curve Pool Gauge address as a string.">Gauge Address:</label>
+        <input type="text" id="sig_gauge" bind:value={gauge} placeholder="Enter Gauge Address">
+    </div>
+    <div>
+        <label for="sig_amount" title="Enter the amount of LP tokens to stake, as a string.">Amount:</label>
+        <input type="text" id="sig_amount" bind:value={amount} placeholder="Enter Amount to Stake">
+    </div>
+    <div>
+        <label for="stake_pool" title="Enter the address of the Curve Pool as a string.">Curve Pool Address:</label>
+        <input type="text" id="stake_pool" bind:value={pool} placeholder="Enter Curve Pool Address">
+    </div>
+    <div>
+        <label for="stake_selector" title="Enter the selector for the function to call, as a string.">Function Selector:</label>
+        <input type="text" id="stake_selector" bind:value={selector} placeholder="Enter Function Selector">
+    </div>
+    <button on:click={stakeInGauge}>Stake in Gauge</button>
+
+    <!-- UnstakeFromGauge UI Component -->
+    <h2>Unstake From Gauge</h2>
+    <div>
+        <label for="ufg_gauge" title="Enter the Curve Gauge address as a string.">Gauge Address:</label>
+        <input type="text" id="ufg_gauge" bind:value={gauge} placeholder="Enter Gauge Address">
+    </div>
+    <div>
+        <label for="ufg_amount" title="Enter the amount of LP tokens to unstake, as a string.">Amount:</label>
+        <input type="text" id="ufg_amount" bind:value={amount} placeholder="Enter Amount to Unstake">
+    </div>
+    <button on:click={unstakeFromGauge}>Unstake from Gauge</button>
+
+    <!-- ClaimRewards UI Component -->
+    <h2>Claim Rewards</h2>
+    <div>
+        <label for="cr_gauge" title="Enter the address of the Curve Gauge as a string.">Gauge Address:</label>
+        <input type="text" id="cr_gauge" bind:value={gauge} placeholder="Enter Gauge Address">
+    </div>
+    <button on:click={claimRewards}>Claim Rewards</button>    

--- a/src/lib/feesAndReserves.svelte
+++ b/src/lib/feesAndReserves.svelte
@@ -1,0 +1,149 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+    export let token = "";
+    export let amount = "";
+    export let asset = "";
+    export let use_as_collateral = false;
+    export let category_id = 0;
+    export let performance_fee = 0;
+    export let management_fee = 0;
+    export let new_frequency = 0;
+    export let new_max_gas = 0;
+
+
+    /// async functions communicating with protos
+    
+    /// Base Adaptor Functions - TODO: do we need revokeApproval here, I don't see a `message` within the proto.
+
+    /// Adaptor Specific Functions
+    async function updatePerformanceFees() {
+        const result = await invoke("UpdatePerformanceFees", { performance_fee });
+        console.log(result);
+    }
+
+    async function updateManagementFees() {
+        const result = await invoke("UpdateManagementFees", { management_fee });
+        console.log(result);
+    }
+
+    async function changeUpkeepFrequency() {
+        const result = await invoke("ChangeUpkeepFrequency", { new_frequency });
+        console.log(result);
+    }
+
+    async function changeUpkeepMaxGas() {
+        const result = await invoke("ChangeUpkeepMaxGas", { new_max_gas });
+        console.log(result);
+    }  
+    
+    async function setupMetaData() {
+        const result = await invoke("SetupMetaData", { management_fee, performance_fee });
+        console.log(result);
+    }
+
+    async function AdjustIsolationModeAssetAsCollateral() {
+        const result = await invoke("AdjustIsolationModeAssetAsCollateral", { asset, use_as_collateral });
+        console.log(result);
+    }
+
+    async function addAssetsToReserves() {
+        const result = await invoke("AddAssetsToReserves", { amount });
+        console.log(result);
+    }  
+
+    async function withdrawAssetsFromReserves() {
+        const result = await invoke("WithdrawAssetsFromReserves", { amount });
+        console.log(result);
+    }  
+
+    async function prepareFees() {
+        const result = await invoke("PrepareFees", { amount });
+        console.log(result);
+    }  
+
+</script>
+
+<!-- UpdatePerformanceFees -->
+
+<h1>1. UpdatePerformanceFees </h1>
+<div>
+    <label for="performance_fee" title="Enter the performance fee as a uint32.">Performance Fee (as a uint32):</label>
+    <input type="uint32" id="performance_fee" bind:value={performance_fee} placeholder=0 />
+</div>
+
+<button on:click={updatePerformanceFees}>Update Performance Fees</button>
+
+<!-- UpdateManagementFees -->
+
+<h1>2. UpdateManagementFees </h1>
+<div>
+    <label for="management_fee" title="Enter the management fee as a uint32.">Management Fee (as a uint32):</label>
+    <input type="uint32" id="management_fee" bind:value={management_fee} placeholder=0 />
+</div>
+
+<button on:click={updateManagementFees}>Update Management Fees</button>
+
+<!-- ChangeUpkeepFrequency -->
+
+<h1>3. ChangeUpkeepFrequency </h1>
+<div>
+    <label for="new_frequency" title="Enter the new upkeep frequency fee as a uint64.">Upkeep Frequency (as a uint64):</label>
+    <input type="uint64" id="new_frequency" bind:value={new_frequency} placeholder=0 />
+</div>
+
+<button on:click={changeUpkeepFrequency}>Update New Upkeep Frequency</button>
+
+<!-- ChangeUpkeepMaxGas -->
+
+<h1>4. Change Upkeep Max Gas</h1>
+<div>
+    <label for="new_max_gas" title="Enter the new_max_gas as a uint64">New Upkeep Max Gas:</label>
+    <input type="uint64" id="new_max_gas" bind:value={new_max_gas} placeholder=0 />
+</div>
+<button on:click={changeUpkeepMaxGas}>Change Upkeep Max Gas</button>
+
+<!-- SetupMetaData -->
+
+<h1>5. Setup MetaData </h1>
+<div>
+    <label for="management_fee" title="Enter the new MetaData info for management_fee as a uint32">New management_fee:</label>
+    <input type="uint32" id="management_fee" bind:value={management_fee} placeholder=0 />
+</div>
+<button on:click={setupMetaData}>Change MetaData</button>
+
+<!-- AddAssetsToReserves -->
+
+<h1>6. Add Assets to Reserves</h1>
+<div>
+    <label for="amount" title="Enter the amount of assets to add to the reserves as a string">Assets to Add to Reserves:</label>
+    <input type="text" id="amount" bind:value={amount} placeholder=0 />
+</div>
+<button on:click={addAssetsToReserves}>Add Assets to Reserves</button>
+
+<!-- WithdrawAssetsFromReserves -->
+
+<h1>7. Withdraw Assets From Reserves</h1>
+<div>
+    <label for="amount" title="Enter the amount of assets to withdraw from the reserves as a string">Assets to Add to Reserves:</label>
+    <input type="text" id="amount" bind:value={amount} placeholder=0 />
+</div>
+<button on:click={withdrawAssetsFromReserves}>Withdraw Assets from Reserves</button>
+
+<!-- PrepareFees -->
+
+<h1>8. Prepare Fees</h1>
+<div>
+    <label for="amount" title="Enter the amount to prepare as fees as a string">Amount to Prepare as Fees:</label>
+    <input type="text" id="amount" bind:value={amount} placeholder=0 />
+</div>
+<button on:click={prepareFees}>Prepare Fees</button>
+
+
+<!-- Additional text information at the bottom of the page -->
+<div>
+    <h2>Specific Strategist Information</h2>
+    <p>A. The strategist is meant to add to the Fees and Reserves smart contract and split the fees accordingly using the FeesAndReserves adaptor and FeesAndReserves smart contract itself. </p>
+    <p>B. TODO - for more info, see the docs! </p>
+    <!-- Empty lines of spaces -->
+    <br /><br /><br />
+</div>

--- a/src/lib/morpho_aave_v2_a_token.svelte
+++ b/src/lib/morpho_aave_v2_a_token.svelte
@@ -1,0 +1,47 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+
+    /// vars
+    export let a_token_deposit = "";
+    export let amount_to_deposit = "";
+    export let a_token_withdraw = "";
+    export let amount_to_withdraw = "";
+
+    /// async functions communicating with protos
+
+    async function scheduleDepositToAaveV2Morpho() {
+        const result = await invoke("DepositToAaveV2Morpho", { a_token: a_token_deposit, amount_to_deposit });
+        console.log(result);
+    }
+
+    async function scheduleWithdrawFromAaveV2Morpho() {
+        const result = await invoke("WithdrawFromAaveV2Morpho", { a_token: a_token_withdraw, amount_to_withdraw });
+        console.log(result);
+    }
+</script>
+
+<!-- Deposit to Aave V2 Morpho -->
+
+<h1>Deposit to Aave V2 Morpho</h1>
+<div>
+    <label for="a_token_deposit" title="Enter the Aave V2 aToken contract address as a string.">Aave V2 aToken Contract Address:</label>
+    <input type="text" id="a_token_deposit" bind:value={a_token_deposit} placeholder="0xaTokenAddress" />
+</div>
+<div>
+    <label for="amount_to_deposit" title="Enter the amount of the asset to deposit as a string.">Amount of Asset to Deposit:</label>
+    <input type="text" id="amount_to_deposit" bind:value={amount_to_deposit} placeholder="Amount" />
+</div>
+<button on:click={scheduleDepositToAaveV2Morpho}>Deposit</button>
+
+<!-- Withdraw from Aave V2 Morpho -->
+
+<h1>Withdraw from Aave V2 Morpho</h1>
+<div>
+    <label for="a_token_withdraw" title="Enter the Aave V2 aToken contract address as a string.">Aave V2 aToken Contract Address:</label>
+    <input type="text" id="a_token_withdraw" bind:value={a_token_withdraw} placeholder="0xaTokenAddress" />
+</div>
+<div>
+    <label for="amount_to_withdraw" title="Enter the amount of the asset to withdraw as a string.">Amount of Asset to Withdraw:</label>
+    <input type="text" id="amount_to_withdraw" bind:value={amount_to_withdraw} placeholder="Amount" />
+</div>
+<button on:click={scheduleWithdrawFromAaveV2Morpho}>Withdraw</button>

--- a/src/lib/morpho_aave_v2_debt_token.svelte
+++ b/src/lib/morpho_aave_v2_debt_token.svelte
@@ -1,0 +1,47 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+
+    /// vars
+    export let a_token_borrow = "";
+    export let amount_to_borrow = "";
+    export let a_token_repay = "";
+    export let amount_to_repay = "";
+
+    /// async functions communicating with protos
+
+    async function scheduleBorrowFromAaveV2Morpho() {
+        const result = await invoke("BorrowFromAaveV2Morpho", { a_token: a_token_borrow, amount_to_borrow });
+        console.log(result);
+    }
+
+    async function scheduleRepayAaveV2MorphoDebt() {
+        const result = await invoke("RepayAaveV2MorphoDebt", { a_token: a_token_repay, amount_to_repay });
+        console.log(result);
+    }
+</script>
+
+<!-- Borrow from Aave V2 Morpho -->
+
+<h1>1. Borrow from Aave V2 Morpho</h1>
+<div>
+    <label for="a_token_borrow" title="Enter the Aave V2 aToken contract address as a string.">Aave V2 aToken Contract Address:</label>
+    <input type="text" id="a_token_borrow" bind:value={a_token_borrow} placeholder="0xaTokenAddress" />
+</div>
+<div>
+    <label for="amount_to_borrow" title="Enter the amount of the asset to borrow as a string.">Amount of Asset to Borrow:</label>
+    <input type="text" id="amount_to_borrow" bind:value={amount_to_borrow} placeholder="Amount" />
+</div>
+<button on:click={scheduleBorrowFromAaveV2Morpho}>Borrow</button>
+
+<!-- Repay Aave V2 Morpho Debt -->
+
+<h1>2. Repay Aave V2 Morpho Debt</h1>
+<div>
+    <label for="a_token_repay" title="Enter the Aave V2 aToken contract address as a string.">Aave V2 aToken Contract Address:</label>
+    <input type="text" id="a_token_repay" bind:value={a_token_repay} placeholder="0xaTokenAddress" />
+</div>
+<div>
+    <label for="amount_to_repay" title="Enter the amount of the asset to repay as a string.">Amount of Asset to Repay:</label>
+    <input type="text" id="amount_to_repay" bind:value={amount_to_repay} placeholder="Amount" />
+</div>
+<button on:click={scheduleRepayAaveV2MorphoDebt}>Repay</button>

--- a/src/lib/morpho_aave_v3_a_token_collateral.svelte
+++ b/src/lib/morpho_aave_v3_a_token_collateral.svelte
@@ -1,0 +1,47 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+
+    /// vars
+    export let token_to_deposit = "";
+    export let amount_to_deposit = "";
+    export let token_to_withdraw = "";
+    export let amount_to_withdraw = "";
+
+    /// async functions communicating with protos
+
+    async function scheduleDepositToAaveV3Morpho() {
+        const result = await invoke("DepositToAaveV3Morpho", { token_to_deposit, amount_to_deposit });
+        console.log(result);
+    }
+
+    async function scheduleWithdrawFromAaveV3Morpho() {
+        const result = await invoke("WithdrawFromAaveV3Morpho", { token_to_withdraw, amount_to_withdraw });
+        console.log(result);
+    }
+</script>
+
+<!-- Deposit to Aave V3 Morpho -->
+
+<h1>1. Deposit to Aave V3 Morpho</h1>
+<div>
+    <label for="token_to_deposit" title="Enter the ERC-20 token contract address as a string.">ERC-20 Token Contract Address:</label>
+    <input type="text" id="token_to_deposit" bind:value={token_to_deposit} placeholder="0xTokenAddress" />
+</div>
+<div>
+    <label for="amount_to_deposit" title="Enter the amount of the ERC-20 asset to deposit as a string.">Amount of ERC-20 Asset:</label>
+    <input type="text" id="amount_to_deposit" bind:value={amount_to_deposit} placeholder="Amount" />
+</div>
+<button on:click={scheduleDepositToAaveV3Morpho}>Deposit</button>
+
+<!-- Withdraw from Aave V3 Morpho -->
+
+<h1>2. Withdraw from Aave V3 Morpho</h1>
+<div>
+    <label for="token_to_withdraw" title="Enter the ERC-20 token contract address as a string.">ERC-20 Token Contract Address:</label>
+    <input type="text" id="token_to_withdraw" bind:value={token_to_withdraw} placeholder="0xTokenAddress" />
+</div>
+<div>
+    <label for="amount_to_withdraw" title="Enter the amount of the ERC-20 asset to withdraw as a string.">Amount of ERC-20 Asset:</label>
+    <input type="text" id="amount_to_withdraw" bind:value={amount_to_withdraw} placeholder="Amount" />
+</div>
+<button on:click={scheduleWithdrawFromAaveV3Morpho}>Withdraw</button>

--- a/src/lib/morpho_aave_v3_a_token_p2p.svelte
+++ b/src/lib/morpho_aave_v3_a_token_p2p.svelte
@@ -1,0 +1,57 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+
+    /// vars
+    export let token_to_deposit = "";
+    export let amount_to_deposit = "";
+    export let max_iterations_deposit = "";
+    export let token_to_withdraw = "";
+    export let amount_to_withdraw = "";
+    export let max_iterations_withdraw = "";
+
+    /// async functions communicating with protos
+
+    async function scheduleDepositToAaveV3Morpho() {
+        const result = await invoke("DepositToAaveV3Morpho", { token_to_deposit, amount_to_deposit, max_iterations: max_iterations_deposit });
+        console.log(result);
+    }
+
+    async function scheduleWithdrawFromAaveV3Morpho() {
+        const result = await invoke("WithdrawFromAaveV3Morpho", { token_to_withdraw, amount_to_withdraw, max_iterations: max_iterations_withdraw });
+        console.log(result);
+    }
+</script>
+
+<!-- Deposit to Aave V3 Morpho -->
+
+<h1>1. Deposit to Aave V3 Morpho</h1>
+<div>
+    <label for="token_to_deposit" title="Enter the ERC-20 token contract address as a string.">ERC-20 Token Contract Address:</label>
+    <input type="text" id="token_to_deposit" bind:value={token_to_deposit} placeholder="0xTokenAddress" />
+</div>
+<div>
+    <label for="amount_to_deposit" title="Enter the amount of the ERC-20 asset to deposit as a string.">Amount of ERC-20 Asset:</label>
+    <input type="text" id="amount_to_deposit" bind:value={amount_to_deposit} placeholder="Amount" />
+</div>
+<div>
+    <label for="max_iterations_deposit" title="Enter the maximum number of iterations as a string.">Max Iterations:</label>
+    <input type="text" id="max_iterations_deposit" bind:value={max_iterations_deposit} placeholder="Max Iterations" />
+</div>
+<button on:click={scheduleDepositToAaveV3Morpho}>Deposit</button>
+
+<!-- Withdraw from Aave V3 Morpho -->
+
+<h1>2. Withdraw from Aave V3 Morpho</h1>
+<div>
+    <label for="token_to_withdraw" title="Enter the ERC-20 token contract address as a string.">ERC-20 Token Contract Address:</label>
+    <input type="text" id="token_to_withdraw" bind:value={token_to_withdraw} placeholder="0xTokenAddress" />
+</div>
+<div>
+    <label for="amount_to_withdraw" title="Enter the amount of the ERC-20 asset to withdraw as a string.">Amount of ERC-20 Asset:</label>
+    <input type="text" id="amount_to_withdraw" bind:value={amount_to_withdraw} placeholder="Amount" />
+</div>
+<div>
+    <label for="max_iterations_withdraw" title="Enter the maximum number of iterations as a string.">Max Iterations:</label>
+    <input type="text" id="max_iterations_withdraw" bind:value={max_iterations_withdraw} placeholder="Max Iterations" />
+</div>
+<button on:click={scheduleWithdrawFromAaveV3Morpho}>Withdraw</button>

--- a/src/lib/morpho_aave_v3_debt_token.svelte
+++ b/src/lib/morpho_aave_v3_debt_token.svelte
@@ -1,0 +1,52 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+
+    /// vars
+    export let underlying_to_borrow = "";
+    export let amount_to_borrow = "";
+    export let max_iterations_borrow = "";
+    export let token_to_repay = "";
+    export let amount_to_repay = "";
+
+    /// async functions communicating with protos
+
+    async function scheduleBorrowFromAaveV3Morpho() {
+        const result = await invoke("BorrowFromAaveV3Morpho", { underlying: underlying_to_borrow, amount_to_borrow, max_iterations: max_iterations_borrow });
+        console.log(result);
+    }
+
+    async function scheduleRepayAaveV3MorphoDebt() {
+        const result = await invoke("RepayAaveV3MorphoDebt", { token_to_repay, amount_to_repay });
+        console.log(result);
+    }
+</script>
+
+<!-- Borrow from Aave V3 Morpho -->
+
+<h1>1. Borrow from Aave V3 Morpho</h1>
+<div>
+    <label for="underlying_to_borrow" title="Enter the underlying asset to borrow as a string.">Underlying Asset:</label>
+    <input type="text" id="underlying_to_borrow" bind:value={underlying_to_borrow} placeholder="Underlying Asset" />
+</div>
+<div>
+    <label for="amount_to_borrow" title="Enter the amount of the underlying asset to borrow as a string.">Amount to Borrow:</label>
+    <input type="text" id="amount_to_borrow" bind:value={amount_to_borrow} placeholder="Amount to Borrow" />
+</div>
+<div>
+    <label for="max_iterations_borrow" title="Enter the maximum number of iterations to perform as a string.">Max Iterations:</label>
+    <input type="text" id="max_iterations_borrow" bind:value={max_iterations_borrow} placeholder="Max Iterations" />
+</div>
+<button on:click={scheduleBorrowFromAaveV3Morpho}>Borrow</button>
+
+<!-- Repay Aave V3 Morpho Debt -->
+
+<h1>2. Repay Aave V3 Morpho Debt</h1>
+<div>
+    <label for="token_to_repay" title="Enter the ERC-20 token contract address to repay as a string.">Token to Repay:</label>
+    <input type="text" id="token_to_repay" bind:value={token_to_repay} placeholder="Token to Repay" />
+</div>
+<div>
+    <label for="amount_to_repay" title="Enter the amount of the token to repay as a string.">Amount to Repay:</label>
+    <input type="text" id="amount_to_repay" bind:value={amount_to_repay} placeholder="Amount to Repay" />
+</div>
+<button on:click={scheduleRepayAaveV3MorphoDebt}>Repay</button>

--- a/src/lib/oneInch.svelte
+++ b/src/lib/oneInch.svelte
@@ -1,0 +1,49 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+    export let token_in = "";
+    export let token_out = "";
+    export let amount = "";
+    export let swap_call_data = "";
+
+    /// async functions communicating with protos
+    
+    /// Base Adaptor Functions - TODO: do we need revokeApproval here, I don't see a `message` within the proto.
+
+    /// Adaptor Specific Functions
+    async function swapWithOneInch() {
+        const result = await invoke("SwapWithOneInch", { token_in, token_out, amount, swap_call_data});
+        console.log(result);
+    }
+
+</script>
+
+<!-- SwapWithOneInch -->
+
+<h1>1. SwapWithOneInch </h1>
+<div>
+    <label for="token_in" title="Enter the ERC-20 token address as a string.">ERC-20 Token_In Contract Address:</label>
+    <input type="text" id="token_in" bind:value={token_in} placeholder="0xtoken" />
+</div>
+<div>
+    <label for="token_out" title="Enter the ERC-20 token address as a string.">ERC-20 Token_Out Contract Address:</label>
+    <input type="text" id="token_out" bind:value={token_out} placeholder="0xtoken" />
+</div>
+<div>
+    <label for="amount" title="Enter the amount of the ERC-20 asset to borrow as a string.">Amount of ERC-20 Asset:</label>
+    <input type="text" id="amount" bind:value={amount} placeholder="Amount" />
+</div>
+<div>
+    <label for="swap_call_data" title="Enter the swap_call_dataas a bytes32.">Swap Calldata:</label>
+    <input type=0x; id="swap_call_data" bind:value={swap_call_data} placeholder="Swap Calldata" />
+</div>
+
+<button on:click={swapWithOneInch}>Swap with OneInch</button>
+
+<!-- Additional text information at the bottom of the page -->
+<div>
+    <h2>Specific Strategist Information</h2>
+    <p>A. TODO  </p>
+    <p>B. TODO - for more info, see the docs! </p>
+    <!-- Empty lines of spaces -->
+    <br /><br /><br />
+</div>

--- a/src/lib/staking.svelte
+++ b/src/lib/staking.svelte
@@ -1,0 +1,195 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+    
+    // Shared Variables
+    let amount = "";
+    let minAmountOut = "";
+    let wildcard = "";
+    let id = "";
+    let depositAsset = "";
+    let wrapAmount = "";
+    let wrapMinAmountOut = "";
+    let wrapWildcard = "";
+    let unwrapAmount = "";
+    let unwrapMinAmountOut = "";
+    let unwrapWildcard = "";
+    let mintERC20DepositAsset = "";
+    let mintERC20Amount = "";
+    let mintERC20MinAmountOut = "";
+    let mintERC20Wildcard = "";
+    let removeClaimedRequestId = "";
+    let removeClaimedRequestWildcard = "";
+    
+    // Operation-specific Variables
+    let requestBurnAmount = "";
+    let completeBurnId = "";
+    let completeBurnMinAmountOut = "";
+    let cancelBurnId = "";
+    let wrapAmount = "";
+    let unwrapAmount = "";
+    let mintERC20Amount = "";
+    let mintERC20DepositAsset = "";
+    let removeClaimedRequestId = "";
+    
+    // Functions
+    async function mint() {
+        const result = await invoke("mint", { amount, min_amount_out: minAmountOut, wildcard });
+        console.log(result);
+    }
+    
+    async function requestBurn() {
+        const result = await invoke("requestBurn", { amount: requestBurnAmount, wildcard });
+        console.log(result);
+    }
+    
+    async function completeBurn() {
+        const result = await invoke("completeBurn", { id: completeBurnId, min_amount_out: completeBurnMinAmountOut, wildcard });
+        console.log(result);
+    }
+    
+    async function cancelBurn() {
+        const result = await invoke("cancelBurn", { id: cancelBurnId, wildcard });
+        console.log(result);
+    }
+    
+    async function wrap() {
+        const result = await invoke("wrap", { amount: wrapAmount, min_amount_out: minAmountOut, wildcard });
+        console.log(result);
+    }
+    
+    async function unwrap() {
+        const result = await invoke("unwrap", { amount: unwrapAmount, min_amount_out: minAmountOut, wildcard });
+        console.log(result);
+    }
+    
+    async function mintERC20() {
+        const result = await invoke("mintERC20", { deposit_asset: mintERC20DepositAsset, amount: mintERC20Amount, min_amount_out: minAmountOut, wildcard });
+        console.log(result);
+    }
+    
+    async function removeClaimedRequest() {
+        const result = await invoke("removeClaimedRequest", { id: removeClaimedRequestId, wildcard });
+        console.log(result);
+    }
+    </script>
+    
+    <!-- Mint UI Component -->
+    <h2>Mint</h2>
+    <div>
+        <label for="mint_amount" title="Enter the amount of native asset to use for minting, as a string.">Amount:</label>
+        <input type="text" id="mint_amount" bind:value={amount} placeholder="Amount">
+    </div>
+    <div>
+        <label for="mint_minAmountOut" title="Enter the minimum amount of the asset to receive, as a string.">Min Amount Out:</label>
+        <input type="text" id="mint_minAmountOut" bind:value={minAmountOut} placeholder="Min Amount Out">
+    </div>
+    <div>
+        <label for="mint_wildcard" title="Enter the Arbitrary ABI encoded data that can be used by inheriting adaptors as a string.">Wildcard Data:</label>
+        <input type="text" id="mint_wildcard" bind:value={wildcard} placeholder="Wildcard Data">
+    </div>
+    <button on:click={mint}>Mint</button>
+    
+    <!-- RequestBurn UI Component -->
+    <h2>Request Burn</h2>
+    <div>
+        <label for="requestBurn_amount" title="Enter the amount of derivative to burn/withdraw as a string.">Amount:</label>
+        <input type="text" id="requestBurn_amount" bind:value={requestBurnAmount} placeholder="Amount">
+    </div>
+    <div>
+        <label for="requestBurn_wildcard" title="Enter the arbitrary abi encoded data that can be used by inheriting adaptors, as a string.">Wildcard Data:</label>
+        <input type="text" id="requestBurn_wildcard" bind:value={wildcard} placeholder="Wildcard Data">
+    </div>
+    <button on:click={requestBurn}>Request Burn</button>
+    
+    <!-- CompleteBurn UI Component -->
+    <h2>Complete Burn</h2>
+    <div>
+        <label for="completeBurn_id" title="Enter the request ID as a string.">Burn Request ID:</label>
+        <input type="text" id="completeBurn_id" bind:value={completeBurnId} placeholder="Burn Request ID">
+    </div>
+    <div>
+        <label for="completeBurn_minAmountOut" title="Enter the  minimum amount of the asset to receive as a string.">Min Amount Out:</label>
+        <input type="text" id="completeBurn_minAmountOut" bind:value={completeBurnMinAmountOut} placeholder="Min Amount Out">
+    </div>
+    <div>
+        <label for="completeBurn_wildcard" title="Enter the arbitrary ABI encoded data that can be used by inheriting adaptors as a string.">Wildcard Data:</label>
+        <input type="text" id="completeBurn_wildcard" bind:value={wildcard} placeholder="Wildcard Data">
+    </div>
+    <button on:click={completeBurn}>Complete Burn</button>
+    
+    <!-- CancelBurn UI Component -->
+    <h2>Cancel Burn</h2>
+    <div>
+        <label for="cancelBurn_id" title="Enter the id of the burn request as a string.">Burn Request ID:</label>
+        <input type="text" id="cancelBurn_id" bind:value={cancelBurnId} placeholder="Burn Request ID">
+    </div>
+    <div>
+        <label for="cancelBurn_wildcard" title="Enter the arbitrary ABI encoded data that can be used by inheriting adaptors as a string.">Wildcard Data:</label>
+        <input type="text" id="cancelBurn_wildcard" bind:value={wildcard} placeholder="Wildcard Data">
+    </div>
+    <button on:click={cancelBurn}>Cancel Burn</button>
+    
+    <!-- Wrap UI Component -->
+    <h2>Wrap Derivative Asset</h2>
+    <div>
+        <label for="wrapAmount" title="Enter the amount of derivative to wrap, as a string.">Amount to Wrap:</label>
+        <input type="text" id="wrapAmount" bind:value={wrapAmount} placeholder="Enter amount">
+    </div>
+    <div>
+        <label for="wrapMinAmountOut" title="Enter the minimum amount of the asset to receive as a string.">Min Amount Out:</label>
+        <input type="text" id="wrapMinAmountOut" bind:value={wrapMinAmountOut} placeholder="Enter minimum amount out">
+    </div>
+    <div>
+        <label for="wrapWildcard" title="Enter the arbitrary abi encoded data that can be used by inheriting adaptors as a string.">Wildcard Data:</label>
+        <input type="text" id="wrapWildcard" bind:value={wrapWildcard} placeholder="Enter wildcard data">
+    </div>
+    <button on:click={wrap}>Wrap</button>
+    
+    <!-- Unwrap UI Component -->
+    <h2>Unwrap Derivative Asset</h2>
+    <div>
+        <label for="unwrapAmount" title="Enter the amount of wrapped derivative to unwrap as a string.">Amount to Unwrap:</label>
+        <input type="text" id="unwrapAmount" bind:value={unwrapAmount} placeholder="Enter amount">
+    </div>
+    <div>
+        <label for="unwrapMinAmountOut" title="Enter the minimum amount of the asset to receive as a string.">Min Amount Out:</label>
+        <input type="text" id="unwrapMinAmountOut" bind:value={unwrapMinAmountOut} placeholder="Enter minimum amount out">
+    </div>
+    <div>
+        <label for="unwrapWildcard" title="Enter the arbitrary ABI encoded data that can be used by inheriting adaptors as a string.">Wildcard Data:</label>
+        <input type="text" id="unwrapWildcard" bind:value={unwrapWildcard} placeholder="Enter wildcard data">
+    </div>
+    <button on:click={unwrap}>Unwrap</button>
+    
+    <!-- MintERC20 UI Component -->
+    <h2>Mint Derivative Asset with ERC20</h2>
+    <div>
+        <label for="mintERC20DepositAsset" title="Enter the ERC20 asset to mint with as a string.">Deposit Asset Address:</label>
+        <input type="text" id="mintERC20DepositAsset" bind:value={mintERC20DepositAsset} placeholder="Enter deposit asset address">
+    </div>
+    <div>
+        <label for="mintERC20Amount" title="Enter the the amount of `depositAsset` to mint with as a string.">Amount:</label>
+        <input type="text" id="mintERC20Amount" bind:value={mintERC20Amount} placeholder="Enter amount">
+    </div>
+    <div>
+        <label for="mintERC20MinAmountOut" title="Enter the the minimum amount of derivative out as a string.">Min Amount Out:</label>
+        <input type="text" id="mintERC20MinAmountOut" bind:value={mintERC20MinAmountOut} placeholder="Enter minimum amount out">
+    </div>
+    <div>
+        <label for="mintERC20Wildcard" title="Enter the arbitrary abi encoded data that can be used by inheriting adaptors as a string.">Wildcard Data:</label>
+        <input type="text" id="mintERC20Wildcard" bind:value={mintERC20Wildcard} placeholder="Enter wildcard data">
+    </div>
+    <button on:click={mintERC20}>Mint with ERC20</button>
+    
+    <!-- RemoveClaimedRequest UI Component -->
+    <h2>Remove Claimed Request</h2>
+    <div>
+        <label for="removeClaimedRequestId" title="Enter the request ID to remove, as a string.">Request ID:</label>
+        <input type="text" id="removeClaimedRequestId" bind:value={removeClaimedRequestId} placeholder="Enter request ID">
+    </div>
+    <div>
+        <label for="removeClaimedRequestWildcard" title="Enter the arbitrary abi encoded data that can be used by inheriting adaptors, as a string.">Wildcard Data:</label>
+        <input type="text" id="removeClaimedRequestWildcard" bind:value={removeClaimedRequestWildcard} placeholder="Enter wildcard data">
+    </div>
+    <button on:click={removeClaimedRequest}>Remove Claimed Request</button>
+ 

--- a/src/lib/uniswapV3.svelte
+++ b/src/lib/uniswapV3.svelte
@@ -1,0 +1,207 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+
+    // Variables for all operations
+    let token_0 = "";
+    let token_1 = "";
+    let pool_fee = 0;
+    let amount_0 = "";
+    let amount_1 = "";
+    let min_0 = "";
+    let min_1 = "";
+    let tick_lower = 0;
+    let tick_upper = 0;
+    let token_id = ""; // Common variable across multiple messages
+    let liquidity = "";
+    let take_fees = false;
+
+    // Functions for operations
+    async function scheduleOpenPosition() {
+        await invoke("openPosition", { token_0, token_1, pool_fee, amount_0, amount_1, min_0, min_1, tick_lower, tick_upper });
+    }
+
+    async function scheduleClosePosition() {
+        await invoke("closePosition", { token_id, min_0, min_1 });
+    }
+
+    async function scheduleAddToPosition() {
+        await invoke("addToPosition", { token_id, amount_0, amount_1, min_0, min_1 });
+    }
+
+    async function scheduleTakeFromPosition() {
+        await invoke("takeFromPosition", { token_id, liquidity, min_0, min_1, take_fees });
+    }
+
+    async function scheduleCollectFees() {
+        await invoke("collectFees", { token_id, amount_0, amount_1 });
+    }
+
+    async function schedulePurgeAllZeroLiquidityPositions() {
+        await invoke("purgeAllZeroLiquidityPositions", { token_0, token_1 });
+    }
+
+    async function schedulePurgeSinglePosition() {
+        await invoke("purgeSinglePosition", { token_id });
+    }
+
+    async function scheduleRemoveUnownedPositionFromTracker() {
+        await invoke("removeUnownedPositionFromTracker", { token_id, token_0, token_1 });
+    }
+</script>
+
+<!-- UI for OpenPosition -->
+<h2>Open Position</h2>
+<div>
+    <label for="op_token_0" title="Enter the Open Position #0 ERC-20 token contract address as a string.">Token 0:</label>
+    <input type="text" id="op_token_0" bind:value={token_0} placeholder="Enter Token 0 Address">
+</div>
+<div>
+    <label for="op_token_1" title="Enter the Open Position #1 ERC-20 token contract address as a string.">Token 1:</label>
+    <input type="text" id="op_token_1" bind:value={token_1} placeholder="Enter Token 1 Address">
+</div>
+<div>
+    <label for="op_pool_fee" title="Enter the pool fee as a number.">Pool Fee:</label>
+    <input type="number" id="op_pool_fee" bind:value={pool_fee} placeholder="Enter Pool Fee">
+</div>
+<div>
+    <label for="op_amount_0" title="Enter the amount of token0 involved with this function call as a string.">Amount 0:</label>
+    <input type="text" id="op_amount_0" bind:value={amount_0} placeholder="Enter Amount 0">
+</div>
+<div>
+    <label for="op_amount_1" title="Enter the amount of token1 involved with this function call as a string.">Amount 1:</label>
+    <input type="text" id="op_amount_1" bind:value={amount_1} placeholder="Enter Amount 1">
+</div>
+<div>
+    <label for="op_min_0" title="Enter the minimum amount of `token0` to add to liquidity.">Min 0:</label>
+    <input type="text" id="op_min_0" bind:value={min_0} placeholder="Enter Min 0">
+</div>
+<div>
+    <label for="op_min_1" title="Enter the minimum amount of `token1` to add to liquidity.">Min 1:</label>
+    <input type="text" id="op_min_1" bind:value={min_1} placeholder="Enter Min 1">
+</div>
+<div>
+    <label for="op_tick_lower" title="Enter the lower liquidity tick.">Tick Lower:</label>
+    <input type="number" id="op_tick_lower" bind:value={tick_lower} placeholder="Enter Tick Lower">
+</div>
+<div>
+    <label for="op_tick_upper" title="Enter the upper liquidity tick.">Tick Upper:</label>
+    <input type="number" id="op_tick_upper" bind:value={tick_upper} placeholder="Enter Tick Upper">
+</div>
+<button on:click={scheduleOpenPosition}>Open Position</button>
+
+
+<!-- UI for ClosePosition -->
+<h2>Close Position</h2>
+<div>
+    <label for="cp_token_id" title="Enter the UniV3 LP NFT tokenId to close." >Token ID:</label>
+    <input type="text" id="cp_token_id" bind:value={token_id} placeholder="Enter Token ID">
+</div>
+<div>
+    <label for="cp_min_0" title="Enter the minimum amount of `token0` to get from closing this position.">Min 0:</label>
+    <input type="text" id="cp_min_0" bind:value={min_0} placeholder="Enter Minimum 0">
+</div>
+<div>
+    <label for="cp_min_1" title="Enter the minimum amount of `token1` to get from closing this position.">Min 1:</label>
+    <input type="text" id="cp_min_1" bind:value={min_1} placeholder="Enter Minimum 1">
+</div>
+<button on:click={scheduleClosePosition}>Close Position</button>
+
+<!-- UI for AddToPosition -->
+<h2>Add To Position</h2>
+<div>
+    <label for="atp_token_id" title="Enter the UniV3 LP NFT id to add liquidity to.">Token ID:</label>
+    <input type="text" id="atp_token_id" bind:value={token_id} placeholder="Enter Token ID">
+</div>
+<div>
+    <label for="atp_amount_0" title="Enter the amount of `token0` to add to liquidity.">Amount 0:</label>
+    <input type="text" id="atp_amount_0" bind:value={amount_0} placeholder="Enter Amount 0">
+</div>
+<div>
+    <label for="atp_amount_1" title="Enter the amount of `token1` to add to liquidity.">Amount 1:</label>
+    <input type="text" id="atp_amount_1" bind:value={amount_1} placeholder="Enter Amount 1">
+</div>
+<div>
+    <label for="atp_min_0" title="Enter the minimum amount of `token0` to add to liquidity.">Min 0:</label>
+    <input type="text" id="atp_min_0" bind:value={min_0} placeholder="Enter Min 0">
+</div>
+<div>
+    <label for="atp_min_1" title="Enter the minimum amount of `token1` to add to liquidity.">Min 1:</label>
+    <input type="text" id="atp_min_1" bind:value={min_1} placeholder="Enter Min 1">
+</div>
+<button on:click={scheduleAddToPosition}>Add To Position</button>
+
+<!-- UI for TakeFromPosition -->
+<h2>Take From Position</h2>
+<div>
+    <label for="tfp_token_id" title="Enter the UniV3 LP NFT tokenId to take from.">Token ID:</label>
+    <input type="text" id="tfp_token_id" bind:value={token_id} placeholder="Enter Token ID">
+</div>
+<div>
+    <label for="tfp_liquidity" title="Enter the amount of liquidity to take from the position.">Liquidity:</label>
+    <input type="text" id="tfp_liquidity" bind:value={liquidity} placeholder="Enter Liquidity">
+</div>
+<div>
+    <label for="tfp_min_0" title="Enter the minimum amount of `token0` to get from taking liquidity.">Min 0:</label>
+    <input type="text" id="tfp_min_0" bind:value={min_0} placeholder="Enter Min 0">
+</div>
+<div>
+    <label for="tfp_min_1" title="Enter the minimum amount of `token1` to get from taking liquidity.">Min 1:</label>
+    <input type="text" id="tfp_min_1" bind:value={min_1} placeholder="Enter Min 1">
+</div>
+<div>
+    <label for="tfp_take_fees" title="Enter bool indicating whether to collect principal(if false), or principal + fees (if true).">Take Fees:</label>
+    <input type="checkbox" id="tfp_take_fees" bind:checked={take_fees}>
+</div>
+<button on:click={scheduleTakeFromPosition}>Take From Position</button>
+
+<!-- UI for CollectFees -->
+<h2>Collect Fees</h2>
+<div>
+    <label for="cf_token_id" title="Enter the UniV3 LP NFT id to collect fees from.">Token ID:</label>
+    <input type="text" id="cf_token_id" bind:value={token_id} placeholder="Enter Token ID">
+</div>
+<div>
+    <label for="cf_amount_0" title="Enter the amount of `token0` fees to collect use type(uint128).max to get collect all.">Amount 0:</label>
+    <input type="text" id="cf_amount_0" bind:value={amount_0} placeholder="Enter Amount 0">
+</div>
+<div>
+    <label for="cf_amount_1" title="Enter the amount of `token1` fees to collect use type(uint128).max to get collect all.">Amount 1:</label>
+    <input type="text" id="cf_amount_1" bind:value={amount_1} placeholder="Enter Amount 1">
+</div>
+<button on:click={scheduleCollectFees}>Collect Fees</button>
+
+<!-- UI for PurgeAllZeroLiquidityPositions -->
+<h2>Purge All Zero Liquidity Positions</h2>
+<div>
+    <label for="pazlp_token_0" title="Enter the `token0` address that are part of the positions you would like to purge, as a string.">Token 0:</label>
+    <input type="text" id="pazlp_token_0" bind:value={token_0} placeholder="Enter Token 0 Address">
+</div>
+<div>
+    <label for="pazlp_token_1" title="Enter the `token1` address that are part of the positions you would like to purge, as a string">Token 1:</label>
+    <input type="text" id="pazlp_token_1" bind:value={token_1} placeholder="Enter Token 1 Address">
+</div>
+<button on:click={schedulePurgeAllZeroLiquidityPositions}>Purge All Zero Liquidity Positions</button>
+
+<!-- UI for PurgeSinglePosition -->
+<h2>Purge Single Position</h2>
+<div>
+    <label for="psp_token_id" title="Enter the tokenId of the position to purge.">Token ID:</label>
+    <input type="text" id="psp_token_id" bind:value={token_id} placeholder="Enter Token ID">
+</div>
+<button on:click={schedulePurgeSinglePosition}>Purge Single Position</button>
+
+<!-- UI for RemoveUnownedPositionFromTracker -->
+<h2>Remove Unowned Position From Tracker</h2>
+<div>
+    <label for="rupft_token_id" title="Likely unused call, but if needed, enter the tokenId of the position to remove from tracker.">Token ID:</label>
+    <input type="text" id="rupft_token_id" bind:value={token_id} placeholder="Enter Token ID">
+</div>
+<div>
+    <label for="rupft_token_0" title="Likely unused call, but if needed, enter the address of token0 of the position to remove from tracker.">Token 0:</label>
+    <input type="text" id="rupft_token_0" bind:value={token_0} placeholder="Enter Token 0 Address">
+</div>
+<div>
+    <label for="rupft_token_1" title="Likely unused call, but if needed, enter the address of token1 of the position to remove from tracker.">Token 1:</label>
+    <input type="text" id="rupft_token_1" bind:value={token_1} placeholder="Enter Token 1 Address">
+</div>
+<button on:click={scheduleRemoveUnownedPositionFromTracker}>Remove Unowned Position</button>

--- a/src/lib/uniswapV3Swap.svelte
+++ b/src/lib/uniswapV3Swap.svelte
@@ -1,0 +1,62 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+    
+    // Variables for SwapWithUniV2
+    let pathUniV2 = [""];
+    let amountUniV2 = "";
+    let amountOutMinUniV2 = "";
+    
+    // Variables for SwapWithUniV3
+    let pathUniV3 = [""];
+    let poolFeesUniV3 = [0];
+    let amountUniV3 = "";
+    let amountOutMinUniV3 = "";
+    
+    // Function to perform a swap on Uniswap V2
+    async function swapWithUniV2() {
+        const result = await invoke("SwapWithUniV2", { path: pathUniV2, amount: amountUniV2, amount_out_min: amountOutMinUniV2 });
+        console.log(result);
+    }
+    
+    // Function to perform a swap on Uniswap V3
+    async function swapWithUniV3() {
+        const result = await invoke("SwapWithUniV3", { path: pathUniV3, pool_fees: poolFeesUniV3, amount: amountUniV3, amount_out_min: amountOutMinUniV3 });
+        console.log(result);
+    }
+    </script>
+    
+    <!-- UI for SwapWithUniV2 -->
+    <h1>Swap with Uniswap V2</h1>
+    <div>
+        <label for="pathUniV2" title="Enter the address swap path, using an array of strings">Path (separated by commas):</label>
+        <input type="text" id="pathUniV2" bind:value={pathUniV2} placeholder="Enter the token addresses path">
+    </div>
+    <div>
+        <label for="amountUniV2" title="Enter the amount of tokensIn you want to swap, as a string.">Amount:</label>
+        <input type="text" id="amountUniV2" bind:value={amountUniV2} placeholder="Amount of token to swap">
+    </div>
+    <div>
+        <label for="amountOutMinUniV2" title="Enter the minimum amount of tokenOut you desire, as a string.">Minimum Amount Out:</label>
+        <input type="text" id="amountOutMinUniV2" bind:value={amountOutMinUniV2} placeholder="Minimum amount to receive">
+    </div>
+    <button on:click={swapWithUniV2}>Swap on UniV2</button>
+    
+    <h1>Swap with Uniswap V3</h1>
+    <div>
+        <label for="pathUniV3" title="Enter the address swap path, using an array of strings">Path (separated by commas):</label>
+        <input type="text" id="pathUniV3" bind:value={pathUniV3} placeholder="Enter the token addresses path">
+    </div>
+    <div>
+        <label for="poolFeesUniV3" title="Enter the pool fees that will help distinguish which pool to interact with, represented as an array of strings.">Pool Fees (separated by commas):</label>
+        <input type="text" id="poolFeesUniV3" bind:value={poolFeesUniV3} placeholder="Enter pool fees for each path">
+    </div>
+    <div>
+        <label for="amountUniV3" title="Enter the amount of tokensIn you want to swap, as a string.">Amount:</label>
+        <input type="text" id="amountUniV3" bind:value={amountUniV3} placeholder="Amount of token to swap">
+    </div>
+    <div>
+        <label for="amountOutMinUniV3" title="Enter the minimum amount of tokenOut you desire, as a string.">Minimum Amount Out:</label>
+        <input type="text" id="amountOutMinUniV3" bind:value={amountOutMinUniV3} placeholder="Minimum amount to receive">
+    </div>
+    <button on:click={swapWithUniV3}>Swap on UniV3</button>
+        

--- a/src/lib/vesting.svelte
+++ b/src/lib/vesting.svelte
@@ -1,0 +1,100 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+    
+    // Variables
+    let vestingContract = "";
+    let depositId = "";
+    let amount = "";
+    export let vestingContractWithdrawAll = "";
+    export let withdrawAmount = "";
+    export let vestingContractAny = "";
+    export let withdrawAmountAny = "";
+    
+    // Functions
+    async function depositToVesting() {
+        const result = await invoke("depositToVesting", { vesting_contract: vestingContract, amount });
+        console.log(result);
+    }
+    
+    // Function to handle the withdrawal from the vesting contract
+    async function withdrawFromVesting() {
+        const result = await invoke("withdrawFromVesting", {
+            vesting_contract: vestingContract,
+            deposit_id: depositId,
+            amount: withdrawAmount,
+        });
+        console.log(result);
+    }
+
+    // Function to handle the withdrawal from any deposit in the vesting contract
+    async function withdrawAnyFromVesting() {
+        const result = await invoke("withdrawAnyFromVesting", {
+            vesting_contract: vestingContractAny,
+            amount: withdrawAmountAny,
+        });
+        console.log(result);
+    }
+        
+    async function withdrawAllFromVesting() {
+        const result = await invoke("withdrawAllFromVesting", { vesting_contract: vestingContract });
+        console.log(result);
+    }
+    </script>
+    
+    <!-- Deposit To Vesting -->
+    <h1>Deposit To Vesting</h1>
+    <div>
+        <label for="vestingContract" title="Enter the vesting contract address as a string.">Vesting Contract Address:</label>
+        <input type="text" id="vestingContract" bind:value={vestingContract} placeholder="Vesting contract address">
+    </div>
+    <div>
+        <label for="amount" title="Enter the amount to deposit as a string.">Amount to Deposit:</label>
+        <input type="text" id="amount" bind:value={amount} placeholder="Amount">
+    </div>
+    <button on:click={depositToVesting}>Deposit</button>
+    
+    <!-- UI for WithdrawFromVesting Operation -->
+    <h1>Withdraw From Vesting</h1>
+
+    <div>
+        <label for="vestingContract" title="Enter the vesting contract address as a string.">Vesting Contract Address:</label>
+        <input type="text" id="vestingContract" bind:value={vestingContract} placeholder="0xVestingContractAddress" />
+    </div>
+
+    <div>
+        <label for="depositId" title="Enter the depositID as a string.">Deposit ID:</label>
+        <input type="text" id="depositId" bind:value={depositId} placeholder="Deposit ID" />
+    </div>
+
+    <div>
+        <label for="withdrawAmount" title="Enter the amount to withdraw as a string.">Amount to Withdraw:</label>
+        <input type="text" id="withdrawAmount" bind:value={withdrawAmount} placeholder="Amount" />
+    </div>
+
+    <button on:click={withdrawFromVesting}>Withdraw</button>
+    
+    <!-- UI for WithdrawAnyFromVesting Operation -->
+    <h1>Withdraw Any From Vesting</h1>
+
+    <div>
+        <label for="vestingContractAny" title="Enter the vesting contract address as a string.">Vesting Contract Address:</label>
+        <input type="text" id="vestingContractAny" bind:value={vestingContractAny} placeholder="0xVestingContractAddress" />
+    </div>
+
+    <div>
+        <label for="withdrawAmountAny" title="Enter the amount to withdraw as a string.">Amount to Withdraw:</label>
+        <input type="text" id="withdrawAmountAny" bind:value={withdrawAmountAny} placeholder="Amount" />
+    </div>
+
+    <button on:click={withdrawAnyFromVesting}>Withdraw Any</button>
+    
+ <!-- UI for WithdrawAllFromVesting Operation -->
+<h1>Withdraw All From Vesting</h1>
+
+<div>
+    <label for="vestingContractWithdrawAll" title="Enter the vesting contract address from which to withdraw all.">Vesting Contract Address:</label>
+    <input type="text" id="vestingContractWithdrawAll" bind:value={vestingContractWithdrawAll} placeholder="0xVestingContractAddress" />
+</div>
+
+<button on:click={withdrawAllFromVesting}>Withdraw All</button>
+    

--- a/src/lib/zeroX.svelte
+++ b/src/lib/zeroX.svelte
@@ -1,0 +1,46 @@
+<script>
+    import { invoke } from "@tauri-apps/api/tauri";
+    
+    // Variables for swap operation
+    export let tokenIn = "";
+    export let tokenOut = "";
+    export let amount = "";
+    export let swapCallData = "";
+    
+    // Function to handle the swap operation, calling a backend service
+    async function swapWith0x() {
+        const result = await invoke("swapWith0x", {
+            token_in: tokenIn,
+            token_out: tokenOut,
+            amount,
+            swap_call_data: swapCallData,
+        });
+        console.log(result);
+    }
+    </script>
+    
+    <!-- UI for SwapWith0x Operation -->
+    <h1>Swap With 0x</h1>
+    
+    <div>
+        <label for="tokenIn" title="Enter the ERC-20 token contract address to swap from, as a string.">Token In (ERC-20 Contract Address):</label>
+        <input type="text" id="tokenIn" bind:value={tokenIn} placeholder="0xTokenInAddress" />
+    </div>
+    
+    <div>
+        <label for="tokenOut" title="Enter the ERC-20 token contract address to swap to, as a string.">Token Out (ERC-20 Contract Address):</label>
+        <input type="text" id="tokenOut" bind:value={tokenOut} placeholder="0xTokenOutAddress" />
+    </div>
+    
+    <div>
+        <label for="amount" title="Enter the amount of the token to swap, as a string.">Amount to Swap:</label>
+        <input type="text" id="amount" bind:value={amount} placeholder="Amount" />
+    </div>
+    
+    <div>
+        <label for="swapCallData" title="Enter the swap call data, in bytes format.">Swap Call Data:</label>
+        <input type="text" id="swapCallData" bind:value={swapCallData} placeholder="Swap Call Data" />
+    </div>
+    
+    <button on:click={swapWith0x}>Execute Swap</button>
+    


### PR DESCRIPTION
## Core changes:

Development of `.svelte` files for initial round of adaptors. 

There will be docs upgrades as well that pair with these strategist terminal `.svelte` files. These two aspects together will hopefully be enough to onboard strategists, but of course tutorials, etc. would be helpful.

## TODO
- [x] Create initial `.svelte` files: aaveV3, aura, balancer, convexCurve, ctoken, curve, feesAndReserves, OneInch, Staking, UniswapV3, UniswapV3Swap, Vesting, ZeroX
- [ ] Refine `.svelte` files with tool tips
- [ ] Add `baseAdaptor` functionality too.