### PR TITLE
Alex/adaptor call and flashloan improvements

### DIFF
--- a/src/components/Queue.svelte
+++ b/src/components/Queue.svelte
@@ -1,20 +1,33 @@
 <script lang="ts">
-  import { queue } from "$stores/AdapterQueue";
+  import { CellarCall, queue } from "$stores/AdapterQueue"
 
   function clearQueue() {
     queue.set([]);
+  }
+  function removeCall(index: number) {
+    queue.update((calls: CellarCall[]) => {
+      return calls.filter((_, i) => i !== index);
+    });
   }
 
 </script>
 <div class="prose mt-10">
   <h2 class="text-2xl font-bold mb-4">Queue:</h2>
-  <div class="max-w-4xl mx-auto">
+  <div class="max-w-4xl min-w-[250px] mx-auto">
     <div class="bg-white shadow-md rounded-lg overflow-hidden">
 
       <div class="px-4 py-2">
-        {#each $queue as item}
+        {#each $queue as item, index}
           <div class="mb-4">
-            <h2 class="text-xl font-bold not-prose">{item.adaptorName}</h2>
+            <div class="flex flex-row">
+              <h2 class="text-xl font-bold mt-2 not-prose">{item.adaptorName}</h2>
+              <button
+                on:click={() => removeCall(index)}
+                type="button"
+                class="px-1 text-red-500 text-3xl rounded-md hover:text-red-600 "
+              > &times;</button>
+            </div>
+
             {#each Object.entries(item.fields) as [key, value]}
               <div class="mb-2">
                 <p class="font-bold">{key}:</p>
@@ -23,6 +36,7 @@
                 </pre>
               </div>
             {/each}
+
           </div>
         {/each}
       </div>

--- a/src/components/Queue.svelte
+++ b/src/components/Queue.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { CellarCall, queue } from "$stores/AdapterQueue"
+  import { CellarCall, flashLoanCalls, queue } from "$stores/AdapterQueue"
+  import { FlashLoan } from "$lib/type"
 
   function clearQueue() {
     queue.set([]);
@@ -8,6 +9,10 @@
     queue.update((calls: CellarCall[]) => {
       return calls.filter((_, i) => i !== index);
     });
+  }
+  function isFlashloanParams(adaptorName: string, field: string) {
+    return (adaptorName === FlashLoan.AaveV3DebtTokenV1FlashLoan || adaptorName === FlashLoan.BalancerPoolV1FlashLoan)
+      && field === "params"
   }
 
 </script>
@@ -32,7 +37,11 @@
               <div class="mb-2">
                 <p class="font-bold">{key}:</p>
                 <pre class="mt-1 text-gray-700 bg-gray-100">
-                  {JSON.stringify(value, null, 2)}
+                  {#if isFlashloanParams(item.adaptorName ?? "", key)}
+                    {JSON.stringify($flashLoanCalls, null, 2)}
+                    {:else }
+                    {JSON.stringify(value, null, 2)}
+                  {/if}
                 </pre>
               </div>
             {/each}

--- a/src/components/ScheduleRequest.svelte
+++ b/src/components/ScheduleRequest.svelte
@@ -91,16 +91,16 @@
 </script>
 
 <h1 class="text-2xl font-bold mb-4">Schedule Request</h1>
-<div class="mb-4">
-    <label for="cellar_id" class="block mb-1">Cellar:</label>
+<!--<div class="mb-4">-->
+<!--    <label for="cellar_id" class="block mb-1">Cellar:</label>-->
 
-    <select name="cellar_id" id="cellar_id" bind:value={cellar} class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:border-blue-500">
-        {#each Object.entries(Cellars) as [key, value]}
-            <option value={value}>{key}</option>
-        {/each}
-    </select>
- </div>
-{#if cellar === Cellars.CUSTOM}
+<!--    <select name="cellar_id" id="cellar_id" bind:value={cellar} class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:border-blue-500">-->
+<!--        {#each Object.entries(Cellars) as [key, value]}-->
+<!--            <option value={value}>{key}</option>-->
+<!--        {/each}-->
+<!--    </select>-->
+<!-- </div>-->
+<!--{#if cellar === Cellars.CUSTOM}-->
     <div class="mb-4">
         <label for="chain" class="block mb-1">Chain:</label>
         <select name="chain" id="chain" bind:value={cellar.CHAIN} class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:border-blue-500">
@@ -113,7 +113,7 @@
         <label for="address" class="block mb-1">Address:</label>
         <input type="text" id="address" class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:border-blue-500" bind:value={cellar.ADDRESS} placeholder="Enter Cellar Address"/>
     </div>
-{/if}
+<!--{/if}-->
 <div class="mb-4">
     <label for="block_height" class="block mb-1">Block Height:</label>
     <input type="text" id="block_height" class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:border-blue-500" bind:value={blockHeight} placeholder="Enter Block Height"/>

--- a/src/components/ScheduleRequest.svelte
+++ b/src/components/ScheduleRequest.svelte
@@ -46,7 +46,10 @@
             toggleStatesModal();
         }).catch((error) => {
             console.error(error);
-            toggleStatesModal();
+            toast.set({
+                type: ToastType.Error,
+                description: `Error scheduling the request. ${error}`
+            })
         });
         queue.set([]);
         // TODO: Create a request object from the result
@@ -77,7 +80,6 @@
                   description: "Error scheduling a request: " + error
               }
             );
-            toggleStatesModal();
         });
         queue.set([]);
         // TODO: Create a request object from the result

--- a/src/components/adaptors/AdaptorTemplate.svelte
+++ b/src/components/adaptors/AdaptorTemplate.svelte
@@ -42,13 +42,16 @@
       if (fieldValues[call.function] && fieldValues[call.function][field.name]) {
         relevantFields[field.name] = fieldValues[call.function][field.name];
       }
+      if(field.type === 'checkbox' && !fieldValues[call.function][field.name]) {
+        relevantFields[field.name] = false;
+      }
     });
 
-    // If the fields type is array, create js array out of string
     for (const fieldName of Object.keys(relevantFields)) {
       const field = call.fields
         .find((f) => f.name === fieldName);
 
+      // If the fields type is array, create js array out of string
       if (field && field.type === 'array') {
         try {
           const value = relevantFields[fieldName];

--- a/src/components/adaptors/AdaptorTemplate.svelte
+++ b/src/components/adaptors/AdaptorTemplate.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { CellarCall, queue } from "$stores/AdapterQueue";
   import { type Adaptor, type AdaptorCall, Functions } from "$lib/type"
+  import { toast, ToastType } from "$stores/ToastStore"
 
   export let adaptor: Adaptor;
 
   // functionName: { fieldName: value }
-  let fieldValues: Record<string, Record<string, string>> = {};
+  let fieldValues: Record<string, Record<string, any>> = {};
 
   $: {
     resetFieldValues();
@@ -19,21 +20,61 @@
 
 
   function handleInput(callFunction: string, fieldName: string, event: Event) {
-    const input = event.target as HTMLInputElement;
+    const target = event.target as HTMLInputElement;
+    let value: string | number | boolean | [] | null   = target.value;
+
+    if (target.type === 'number') {
+      value = target.value ? Number(target.value) : null;
+    } else if (target.type === 'checkbox') {
+      value = target.checked;
+    }
+
     if (!fieldValues[callFunction]) {
       fieldValues[callFunction] = {};
     }
-    fieldValues[callFunction][fieldName] = input.value;
+    fieldValues[callFunction][fieldName] = value;
   }
 
-  function scheduleCall(call: AdaptorCall) {
-    const relevantFields: Record<string, string> = {};
+  function addCallToQueue(call: AdaptorCall) {
+    const relevantFields: Record<string, any> = {};
 
     call.fields.forEach(field => {
       if (fieldValues[call.function] && fieldValues[call.function][field.name]) {
         relevantFields[field.name] = fieldValues[call.function][field.name];
       }
     });
+
+    // If the fields type is array, create js array out of string
+    for (const fieldName of Object.keys(relevantFields)) {
+      const field = call.fields
+        .find((f) => f.name === fieldName);
+
+      if (field && field.type === 'array') {
+        try {
+          const value = relevantFields[fieldName];
+
+          const parsedValue = JSON.parse(value);
+
+          if (Array.isArray(parsedValue)) {
+            relevantFields[fieldName] = parsedValue;
+          } else {
+            toast.set({
+              type: ToastType.Error,
+              description: `Error with array format on ${fieldName}.`
+            });
+            return;
+          }
+        } catch (error) {
+          console.error("Error parsing array field", fieldName, error);
+          toast.set({
+            type: ToastType.Error,
+            description: `Error parsing array on ${fieldName}. ${error}`
+          });
+          relevantFields[fieldName] = [];
+          return;
+        }
+      }
+    }
 
     queue.update((callQueue) => {
       callQueue.push(
@@ -66,20 +107,23 @@
       <h2>{index + 1}. {call.function}</h2>
 
       {#each call.fields as field}
-        <div class="flex justify-between mt-2">
-          <label for="{`${call.function}-${field.name}`}">{field.label}:</label>
+        <div class="flex mt-2">
+          <label for="{`${call.function}-${field.name}`}" class="w-[250px] mr-[70px]">{field.label}:</label>
           <input
-            value={fieldValues[call.function]?.[field.name] || ''}
+            type={field.type ?? 'text'}
+            value={fieldValues[call.function]?.[field.name] ?? ''}
             on:input={(event) => handleInput(call.function, field.name, event)}
             id="{`${call.function}-${field.name}`}"
             placeholder="{field.placeholder}"
-            class="w-100 px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:border-blue-500"
+            checked={false}
+            class="px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:border-blue-500
+                  {field.type === 'checkbox' ? 'w-[25px]' : 'w-[250px]'}"
           />
         </div>
       {/each}
 
       <button
-        on:click={() => scheduleCall(call)}
+        on:click={() => addCallToQueue(call)}
         type="button"
         class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:bg-blue-600 mt-3"
       >{call.action}</button>

--- a/src/components/flashLoan/AdaptorSelection.svelte
+++ b/src/components/flashLoan/AdaptorSelection.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 
-  import adaptorList, { type Adaptor } from "$lib/adaptorList"
+  import adaptorList from "$lib/adaptorList"
   import CallSelection from "./CallSelection.svelte"
+  import type { Adaptor } from "$lib/type"
 
   export let closeAdaptorSelection: () => void;
 

--- a/src/components/flashLoan/CallSelection.svelte
+++ b/src/components/flashLoan/CallSelection.svelte
@@ -79,6 +79,6 @@
 
   <button
     on:click={addCall}
-    class="p-2.5 border rounded focus:outline-none bg-gray-100 text-black border-gray-300"
-  >Add call</button>
+    class="p-2.5 border rounded focus:outline-none bg-blue-500 text-white border-gray-300"
+  >Add call to flashloan</button>
 {/if}

--- a/src/components/flashLoan/CallSelection.svelte
+++ b/src/components/flashLoan/CallSelection.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-  import type { Adaptor, AdaptorCall } from "$lib/adaptorList"
   import { CellarCall, flashLoanCalls } from "$stores/AdapterQueue"
-  import { Functions } from "$lib/type"
+  import { type Adaptor, type AdaptorCall, Functions } from "$lib/type"
 
   export let adaptor: Adaptor;
   export let closeAdaptorSelection: () => void;

--- a/src/components/flashLoan/FlashLoansTab.svelte
+++ b/src/components/flashLoan/FlashLoansTab.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import AdaptorSelection from "./AdaptorSelection.svelte"
   import { CellarCall, flashLoanCalls, queue } from "$stores/AdapterQueue"
-  import { Functions } from "$lib/type"
+  import { Functions, PlaceHolder } from "$lib/type"
 
   let adaptorSelectionOpen = false;
   let addCallBtnVisible = true;
@@ -107,7 +107,7 @@
   <input
     bind:value={adaptorAddress}
     id="adaptorAddress"
-    placeholder={adaptorAddress}
+    placeholder={PlaceHolder.Address}
     class="w-full px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:border-blue-500"
   />
 
@@ -116,7 +116,7 @@
     <input
       bind:value={tokens}
       id="tokens"
-      placeholder='e.g., ["0x000...", "0x000..."]'
+      placeholder={PlaceHolder.ArrayOfAddress}
       class="w-100 px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:border-blue-500"
     />
   </div>
@@ -126,7 +126,7 @@
     <input
       bind:value={amounts}
       id="amounts"
-      placeholder='e.g., ["50", "100"]'
+      placeholder={PlaceHolder.ArrayOfString}
       class="w-100 px-2 py-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:border-blue-500"
     />
   </div>

--- a/src/components/flashLoan/FlashLoansTab.svelte
+++ b/src/components/flashLoan/FlashLoansTab.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import AdaptorSelection from "./AdaptorSelection.svelte"
   import { CellarCall, flashLoanCalls, queue } from "$stores/AdapterQueue"
-  import { Functions, PlaceHolder } from "$lib/type"
+  import { FlashLoan, Functions, PlaceHolder } from "$lib/type"
 
   let adaptorSelectionOpen = false;
   let addCallBtnVisible = true;
@@ -49,7 +49,7 @@
           params: []
         },
         adaptorAddress,
-        "AaveV3DebtTokenV1FlashLoan"
+        FlashLoan.AaveV3DebtTokenV1FlashLoan
       );
     } else {
       cellarCall = new CellarCall(
@@ -60,7 +60,7 @@
           data: []
         },
         adaptorAddress,
-        "BalancerPoolV1FlashLoan");
+        FlashLoan.BalancerPoolV1FlashLoan);
     }
 
     queue.update((callQueue) => {

--- a/src/components/flashLoan/FlashLoansTab.svelte
+++ b/src/components/flashLoan/FlashLoansTab.svelte
@@ -140,19 +140,22 @@
   {/if}
 
   {#each $flashLoanCalls as call, index (index)}
+    <div class="flex justify-between mt-2 ml-5">
         <h4>{call.adaptorName}</h4>
+        <button
+          on:click={() => removeCall(index)}
+          type="button"
+          class="px-1 text-red-500 text-3xl rounded-md hover:text-red-600 "
+        > &times;</button>
+    </div>
         {#each Object.entries(call.fields) as [key, value]}
-          <div class="flex justify-between mt-2 ml-5">
-            <div>
-              {key}: {JSON.stringify(value)}
-            </div>
-            <button
-              on:click={() => removeCall(index)}
-              type="button"
-              class="px-1 text-red-500 text-3xl rounded-md hover:text-red-600 "
-            > &times;</button>
 
-          </div>
+            <pre class="mt-1 bg-gray-500">
+              {key}: {JSON.stringify(value, null, 2)}
+            </pre>
+
+
+
 
         {/each}
   {/each}
@@ -162,7 +165,7 @@
       on:click={openAdaptorSelection}
       type="button"
       class="px-3 py-1 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:bg-blue-600 my-5"
-    >Add</button>
+    >Add new call</button>
   {/if}
 
 
@@ -177,4 +180,4 @@
   on:click={requestFlashLoan}
   type="button"
   class="px-5 py-3 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:bg-blue-600 m-5 text-xl"
->Add to queue</button>
+>Schedule a flashloan</button>

--- a/src/lib/adaptorList.ts
+++ b/src/lib/adaptorList.ts
@@ -12,7 +12,7 @@ import CompoundCTokenV2 from "$lib/adaptors/CompoundCTokenV2"
 import ConvexCurveV1 from "$lib/adaptors/ConvexCurveV1"
 import CurveV1 from "$lib/adaptors/CurveV1"
 import DebtFTokenV1 from "$lib/adaptors/DebtFTokenV1"
-import Erc4626V1V1 from "$lib/adaptors/Erc4626V1"
+import Erc4626V1 from "$lib/adaptors/Erc4626V1"
 import FeesAndReservesV1 from "$lib/adaptors/FeesAndReservesV1"
 import FTokenV1 from "$lib/adaptors/FTokenV1"
 import LegacyCellarV1 from "$lib/adaptors/LegacyCellarV1"
@@ -48,7 +48,7 @@ const adaptors: Adaptor[] = [
   ConvexCurveV1,
   CurveV1,
   DebtFTokenV1,
-  Erc4626V1V1,
+  Erc4626V1,
   FeesAndReservesV1,
   FTokenV1,
   LegacyCellarV1,

--- a/src/lib/adaptors/AaveATokenV1.ts
+++ b/src/lib/adaptors/AaveATokenV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import type { Adaptor } from "$lib/type"
 
 const AaveATokenV1: Adaptor = {
   name: "AaveATokenV1",
@@ -11,12 +11,14 @@ const AaveATokenV1: Adaptor = {
         {
           name: "token",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xtoken"
+          placeholder: "0xtoken",
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount"
+          placeholder: "Amount",
+          type: "text"
         }
       ]
     },
@@ -27,12 +29,14 @@ const AaveATokenV1: Adaptor = {
         {
           name: "token",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xtoken"
+          placeholder: "0xtoken",
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount"
+          placeholder: "Amount",
+          type: "text"
         }
       ]
     },

--- a/src/lib/adaptors/AaveATokenV2.ts
+++ b/src/lib/adaptors/AaveATokenV2.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const AaveATokenV2: Adaptor = {
   name: "AaveATokenV2",
@@ -11,12 +11,14 @@ const AaveATokenV2: Adaptor = {
         {
           name: "token",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xtoken"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -27,12 +29,14 @@ const AaveATokenV2: Adaptor = {
         {
           name: "token",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xtoken"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },

--- a/src/lib/adaptors/AaveDebtTokenV1.ts
+++ b/src/lib/adaptors/AaveDebtTokenV1.ts
@@ -11,13 +11,13 @@ const AaveDebtTokenV1: Adaptor = {
         {
           name: "token",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xtoken",
+          placeholder: PlaceHolder.Address,
           type: "text"
         },
         {
           name: "amount",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount",
+          placeholder: PlaceHolder.Text,
           type: "text"
         }
       ]
@@ -29,13 +29,13 @@ const AaveDebtTokenV1: Adaptor = {
         {
           name: "token",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xtoken",
+          placeholder: PlaceHolder.Address,
           type: "text"
         },
         {
           name: "amount",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount",
+          placeholder: PlaceHolder.Text,
           type: "text"
         }
       ]

--- a/src/lib/adaptors/AaveDebtTokenV1.ts
+++ b/src/lib/adaptors/AaveDebtTokenV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const AaveDebtTokenV1: Adaptor = {
   name: "AaveDebtTokenV1",
@@ -11,12 +11,14 @@ const AaveDebtTokenV1: Adaptor = {
         {
           name: "token",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xtoken"
+          placeholder: "0xtoken",
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount"
+          placeholder: "Amount",
+          type: "text"
         }
       ]
     },
@@ -27,12 +29,14 @@ const AaveDebtTokenV1: Adaptor = {
         {
           name: "token",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xtoken"
+          placeholder: "0xtoken",
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount"
+          placeholder: "Amount",
+          type: "text"
         }
       ]
     },
@@ -43,22 +47,32 @@ const AaveDebtTokenV1: Adaptor = {
         {
           name: "token_in",
           label: "The address of the token to swap from",
-          placeholder: "0xtoken"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "token_to_repay",
           label: "The address of the token to swap to and repay with",
-          placeholder: "0xtoken"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
-          name: "amount",
+          name: "amount_in",
           label: "The amount to swap",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "exchange",
           label: "The exchange to make the swap on",
-          placeholder: "Exchange"
+          placeholder: PlaceHolder.Empty,
+          type: "number"
+        },
+        {
+          name: "params",
+          label: "The parameters for the swap",
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },

--- a/src/lib/adaptors/AaveDebtTokenV2.ts
+++ b/src/lib/adaptors/AaveDebtTokenV2.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const AaveDebtTokenV2: Adaptor = {
   name: "AaveDebtTokenV2",
@@ -11,12 +11,14 @@ const AaveDebtTokenV2: Adaptor = {
         {
           name: "token",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xtoken"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -27,12 +29,14 @@ const AaveDebtTokenV2: Adaptor = {
         {
           name: "token",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xtoken"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/AaveV2EnableAssetAsCollateralV1.ts
+++ b/src/lib/adaptors/AaveV2EnableAssetAsCollateralV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const AaveV2EnableAssetAsCollateralV1: Adaptor = {
   name: "AaveV2EnableAssetAsCollateralV1",
@@ -11,12 +11,14 @@ const AaveV2EnableAssetAsCollateralV1: Adaptor = {
         {
           name: "asset",
           label: "The address of the asset to set as collateral",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "use_as_collateral",
           label: "Use the asset as collateral",
-          placeholder: "Boolean"
+          placeholder: PlaceHolder.Empty,
+          type: "checkbox"
         }
       ]
     }

--- a/src/lib/adaptors/AaveV3ATokenV1.ts
+++ b/src/lib/adaptors/AaveV3ATokenV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const AaveV3ATokenV1: Adaptor = {
   name: "AaveV3ATokenV1",
@@ -11,12 +11,14 @@ const AaveV3ATokenV1: Adaptor = {
         {
           name: "token",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xtoken"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -27,12 +29,14 @@ const AaveV3ATokenV1: Adaptor = {
         {
           name: "token",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xtoken"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -43,12 +47,14 @@ const AaveV3ATokenV1: Adaptor = {
         {
           name: "asset",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xtoken"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "use_as_collateral",
           label: "Use as Collateral",
-          placeholder: "boolean"
+          placeholder: PlaceHolder.Empty,
+          type: "checkbox"
         }
       ]
     },
@@ -59,7 +65,8 @@ const AaveV3ATokenV1: Adaptor = {
         {
           name: "category_id",
           label: "Category ID",
-          placeholder: "ID"
+          placeholder: PlaceHolder.Empty,
+          type: "number"
         }
 
       ]

--- a/src/lib/adaptors/AaveV3ATokenV1.ts
+++ b/src/lib/adaptors/AaveV3ATokenV1.ts
@@ -59,7 +59,7 @@ const AaveV3ATokenV1: Adaptor = {
       ]
     },
     {
-      function: "ChangeEMode",
+      function: "ChangeEmode",
       action: "Change",
       fields: [
         {

--- a/src/lib/adaptors/AaveV3DebtTokenV1.ts
+++ b/src/lib/adaptors/AaveV3DebtTokenV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const AaveV3DebtTokenV1: Adaptor = {
   name: "AaveV3DebtTokenV1",
@@ -11,12 +11,14 @@ const AaveV3DebtTokenV1: Adaptor = {
         {
           name: "token",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xtoken"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -27,12 +29,14 @@ const AaveV3DebtTokenV1: Adaptor = {
         {
           name: "token",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xtoken"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -43,12 +47,14 @@ const AaveV3DebtTokenV1: Adaptor = {
         {
           name: "underlying_token",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xtoken"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount of AToken to Repay",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/AuraErc4626V1.ts
+++ b/src/lib/adaptors/AuraErc4626V1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const AuraErc4626V1: Adaptor = {
   name: "AuraErc4626V1",
@@ -11,12 +11,14 @@ const AuraErc4626V1: Adaptor = {
         {
           name: "aura_pool",
           label: "Aura Pool Address",
-          placeholder: "Enter Aura Pool Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "claim_extras",
           label: "Claim Extra Rewards",
-          placeholder: "Boolean"
+          placeholder: PlaceHolder.Empty,
+          type: "checkbox"
         }
       ]
     }

--- a/src/lib/adaptors/BalancerPoolV1.ts
+++ b/src/lib/adaptors/BalancerPoolV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const BalancerPoolV1: Adaptor = {
   name: "BalancerPoolV1",
@@ -11,32 +11,38 @@ const BalancerPoolV1: Adaptor = {
         {
           name: "pool_id",
           label: "Pool ID",
-          placeholder: "Enter Pool ID"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "kind",
           label: "Swap Kind",
-          placeholder: "Kind"
+          placeholder: PlaceHolder.Empty,
+          type: "number"
         },
         {
           name: "asset_in",
           label: "The asset in",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "asset_out",
           label: "The asset out",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount",
           label: "The amount",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "user_data",
           label: "The user data",
-          placeholder: "User data"
+          placeholder: PlaceHolder.ArrayOfNumber,
+          type: "array"
         }
       ]
     },
@@ -47,12 +53,14 @@ const BalancerPoolV1: Adaptor = {
         {
           name: "min_amounts_for_swaps",
           label: "The minimum amounts for swaps",
-          placeholder: "Amounts"
+          placeholder: PlaceHolder.ArrayOfString,
+          type: "array"
         },
         {
           name: "swap_deadlines",
           label: "The swap deadlines",
-          placeholder: "Deadlines"
+          placeholder: PlaceHolder.ArrayOfString,
+          type: "array"
         }
       ]
     },
@@ -63,22 +71,27 @@ const BalancerPoolV1: Adaptor = {
         {
           name: "target_bpt",
           label: "Target BPT",
-          placeholder: "BPT"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "swaps_before_join",
           label: "Swap to execute before joining pool",
-          placeholder: "Swap"
+          placeholder: PlaceHolder.ArrayOfString,
+          type: "array"
         },
         {
           name: "swap_data",
           label: "Data for swaps",
-          placeholder: "Data"
+          placeholder: PlaceHolder.ArrayOfString,
+          // "{min_amounts_for_swaps: ['1'], swap_deadlines: : ['1']}",
+          type: "text"
         },
         {
           name: "minimum_bpt",
           label: "The minimum BPT to mint",
-          placeholder: "BPT"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -89,22 +102,27 @@ const BalancerPoolV1: Adaptor = {
         {
           name: "assets",
           label: "Assets",
-          placeholder: "Asset Addresses, comma-separated"
+          placeholder: PlaceHolder.ArrayOfAddress,
+          type: "array"
         },
         {
           name: "min_amounts_out",
           label: "Minimum Amounts Out",
-          placeholder: "Minimum Amounts, comma-separated"
+          placeholder: PlaceHolder.ArrayOfString,
+          type: "array"
         },
         {
           name: "user_data",
           label: "User Data",
-          placeholder: "User Data in bytes"
+          placeholder: PlaceHolder.ArrayOfNumber,
+          type: "array"
         },
         {
           name: "to_internal_balance",
           label: "To Internal Balance",
-          placeholder: "Boolean"
+          placeholder: PlaceHolder.Empty,
+          type: "checkbox"
+
         }
       ]
     },
@@ -115,22 +133,26 @@ const BalancerPoolV1: Adaptor = {
         {
           name: "exit_target_bpt",
           label: "Swaps to execute after exiting pool",
-          placeholder: "Swaps"
+          placeholder: PlaceHolder.Empty,
+          type: "text"
         },
         {
           name: "swaps_after_exit",
           label: "Target BPT",
-          placeholder: "Enter Target BPT"
+          placeholder: PlaceHolder.ArrayOfString,
+          type: "array"
         },
         {
           name: "swap_data",
           label: "Exit swap data",
-          placeholder: "Swap Data"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "request",
           label: "Request",
-          placeholder: "Request"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -141,17 +163,20 @@ const BalancerPoolV1: Adaptor = {
         {
           name: "bpt",
           label: "BPT",
-          placeholder: "BPT Address"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "liquidity_gauge",
           label: "Liquidity Gauge",
-          placeholder: "Liquidity Gauge Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_in",
           label: "Amount",
-          placeholder: "Amount to Stake"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -162,38 +187,20 @@ const BalancerPoolV1: Adaptor = {
         {
           name: "bpt",
           label: "BPT",
-          placeholder: "BPT Address"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "liquidity_gauge",
           label: "Liquidity Gauge",
-          placeholder: "Liquidity Gauge Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_in",
           label: "Amount",
-          placeholder: "Amount to Unstake"
-        }
-      ]
-    },
-    {
-      function: "UnstakeBPT",
-      action: "Unstake BPT",
-      fields: [
-        {
-          name: "bpt",
-          label: "BPT",
-          placeholder: "BPT Address"
-        },
-        {
-          name: "liquidity_gauge",
-          label: "Liquidity Gauge",
-          placeholder: "Liquidity Gauge Address"
-        },
-        {
-          name: "amount_in",
-          label: "Amount",
-          placeholder: "Amount to Unstake"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -204,7 +211,8 @@ const BalancerPoolV1: Adaptor = {
         {
           name: "gauge",
           label: "Gauge",
-          placeholder: "Gauge Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/CollateralFTokenV1.ts
+++ b/src/lib/adaptors/CollateralFTokenV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const CollateralFTokenV1: Adaptor = {
   name: "CollateralFTokenV1",
@@ -11,12 +11,14 @@ const CollateralFTokenV1: Adaptor = {
         {
           name: "fraxlend_pair",
           label: "The FraxLend pair to add collateral to",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "collateral_to_deposit",
           label: "The amount of collateral to add to the cellar position",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -27,12 +29,14 @@ const CollateralFTokenV1: Adaptor = {
         {
           name: "collateral_amount",
           label: "The amount of collateral to remove from the cellar position",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "fraxlend_pair",
           label: "The FraxLend pair to remove collateral from",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/CompoundCTokenV2.ts
+++ b/src/lib/adaptors/CompoundCTokenV2.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const CompoundCTokenV2: Adaptor = {
   name: "CompoundCTokenV2",
@@ -11,12 +11,14 @@ const CompoundCTokenV2: Adaptor = {
         {
           name: "market",
           label: "Enter the Compound market address",
-          placeholder: "Market"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_to_deposit",
           label: "Enter amount to deposit",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -27,12 +29,14 @@ const CompoundCTokenV2: Adaptor = {
         {
           name: "market",
           label: "Enter the Compound market address",
-          placeholder: "Market"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_to_withdraw",
           label: "Enter amount to withdraw",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },

--- a/src/lib/adaptors/ConvexCurveV1.ts
+++ b/src/lib/adaptors/ConvexCurveV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const ConvexCurveV1: Adaptor = {
   name: "ConvexCurveV1",
@@ -11,32 +11,38 @@ const ConvexCurveV1: Adaptor = {
         {
           name: "pid",
           label: "PID",
-          placeholder: "Enter PID"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "base_reward_pool",
           label: "Base Reward Pool",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "lpt",
           label: "lpt",
-          placeholder: "lpt"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "pool",
           label: "pool",
-          placeholder: "pool"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "selector",
           label: "selector",
-          placeholder: "selector"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "amount_to_deposit",
           label: "Enter amount to deposit",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -47,17 +53,20 @@ const ConvexCurveV1: Adaptor = {
         {
           name: "base_reward_pool",
           label: "Enter Base Reward Pool Address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_to_withdraw",
           label: "Enter amount to withdraw",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "claim",
           label: "Enter whether or not to rewards associated to respective ConvexCurve market position, as a bool",
-          placeholder: "Boolean"
+          placeholder: PlaceHolder.Empty,
+          type: "checkbox"
         }
       ]
     },
@@ -68,12 +77,14 @@ const ConvexCurveV1: Adaptor = {
         {
           name: "base_reward_pool",
           label: "Enter Base Reward Pool Address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "claim_extras",
           label: "Claim Extras",
-          placeholder: "Boolean"
+          placeholder: PlaceHolder.Empty,
+          type: "checkbox"
         }
       ]
     }

--- a/src/lib/adaptors/CurveV1.ts
+++ b/src/lib/adaptors/CurveV1.ts
@@ -47,7 +47,7 @@ const CurveV1: Adaptor = {
       ]
     },
     {
-      function: "AddLiquidityETH",
+      function: "AddLiquidityEth",
       action: "Add Liquidity with ETH",
       fields: [
         {
@@ -137,7 +137,7 @@ const CurveV1: Adaptor = {
       ]
     },
     {
-      function: "RemoveLiquidityETH",
+      function: "RemoveLiquidityEth",
       action: "Remove Liquidity with ETH",
       fields: [
         {

--- a/src/lib/adaptors/CurveV1.ts
+++ b/src/lib/adaptors/CurveV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const CurveV1: Adaptor = {
   name: "CurveV1",
@@ -11,32 +11,38 @@ const CurveV1: Adaptor = {
         {
           name: "pool",
           label: "Enter Curve Pool Address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "lp_token",
           label: "Enter LP Token Address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "ordered_underlying_token_amounts",
-          label: "Enter the minimum amount of each underlying token to receive, as an array of strings",
-          placeholder: "e.g., [50, 100]"
+          label: "Enter the minimum amount of each underlying token to receive",
+          placeholder: PlaceHolder.ArrayOfString,
+          type: "array"
         },
         {
           name: "min_lp_amount",
           label: "Enter the minimum amount of LP tokens to receive, as a string",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "gauge",
           label: "Enter the curve gauge address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "selector",
           label: "Enter the selector",
-          placeholder: "Selector"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -47,37 +53,44 @@ const CurveV1: Adaptor = {
         {
           name: "pool",
           label: "Enter Curve Pool Address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "lp_token",
           label: "Enter LP Token Address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "ordered_underlying_token_amounts",
-          label: "Enter the minimum amount of each underlying token to receive, as an array of strings",
-          placeholder: "e.g., [50, 100]"
+          label: "Enter the minimum amount of each underlying token to receive",
+          placeholder: PlaceHolder.ArrayOfString,
+          type: "array"
         },
         {
           name: "min_lp_amount",
           label: "Enter the minimum amount of LP tokens to receive",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "use_underlying",
           label: "Enter a bool for whether to use the underlying asset or the wrapped asset",
-          placeholder: "Boolean"
+          placeholder: PlaceHolder.Empty,
+          type: "checkbox"
         },
         {
           name: "gauge",
           label: "Enter the curve gauge address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "selector",
           label: "Enter the selector",
-          placeholder: "Selector"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -88,32 +101,38 @@ const CurveV1: Adaptor = {
         {
           name: "pool",
           label: "Enter the Curve Pool address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "lp_token",
           label: "Enter the curve pool token address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "lp_token_amount",
           label: "Enter the LP Token Amount",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "ordered_minimum_underlying_token_amounts_out",
-          label: "Enter the minimum amount of each underlying token to receive, as an array of strings",
-          placeholder: "e.g., [50, 100]"
+          label: "Enter the minimum amount of each underlying token to receive",
+          placeholder: PlaceHolder.ArrayOfString,
+          type: "array"
         },
         {
           name: "gauge",
           label: "Enter the curve gauge address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "selector",
           label: "Enter the selector",
-          placeholder: "Selector"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -124,37 +143,44 @@ const CurveV1: Adaptor = {
         {
           name: "pool",
           label: "Enter the Curve Pool address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "lp_token",
           label: "Enter the curve pool token address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "lp_token_amount",
           label: "Enter the LP Token Amount",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "ordered_minimum_underlying_token_amounts_out",
-          label: "Enter the minimum amount of each underlying token to receive, as an array of strings",
-          placeholder: "e.g., [50, 100]"
+          label: "Enter the minimum amount of each underlying token to receive",
+          placeholder: PlaceHolder.ArrayOfString,
+          type: "array"
         },
         {
           name: "use_underlying",
           label: "Use Underlying",
-          placeholder: "Boolean"
+          placeholder: PlaceHolder.Empty,
+          type: "checkbox"
         },
         {
           name: "gauge",
           label: "Enter the curve gauge address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "selector",
           label: "Enter the selector",
-          placeholder: "Selector"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -165,27 +191,32 @@ const CurveV1: Adaptor = {
         {
           name: "lp_token",
           label: "Enter the address of the LP token",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "gauge",
           label: "Enter the Curve Pool Gauge address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount",
           label: "Enter the amount of LP tokens to stake",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "pool",
           label: "Enter the address of the Curve Pool",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "selector",
           label: "Enter the selector for the function to call",
-          placeholder: "Selector"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -196,12 +227,14 @@ const CurveV1: Adaptor = {
         {
           name: "gauge",
           label: "Enter the Curve Pool Gauge address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount",
           label: "Enter the amount of LP tokens to unstake",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -212,7 +245,8 @@ const CurveV1: Adaptor = {
         {
           name: "gauge",
           label: "Enter the address of the Curve Gauge",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/DebtFTokenV1.ts
+++ b/src/lib/adaptors/DebtFTokenV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const DebtFTokenV1: Adaptor = {
   name: "DebtFTokenV1",
@@ -11,12 +11,14 @@ const DebtFTokenV1: Adaptor = {
         {
           name: "fraxlend_pair",
           label: "The address of the Frax Pair to borrow from",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_to_borrow",
           label: "The amount of the asset to borrow",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -27,12 +29,14 @@ const DebtFTokenV1: Adaptor = {
         {
           name: "fraxlend_pair",
           label: "The address of the Frax Pair to repay debt on",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "debt_token_repay_amount",
           label: "The amount of the debt token to repay",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -43,7 +47,8 @@ const DebtFTokenV1: Adaptor = {
         {
           name: "fraxlend_pair",
           label: "The address of the Frax Pair to call addInterest on",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/Erc4626V1.ts
+++ b/src/lib/adaptors/Erc4626V1.ts
@@ -1,7 +1,7 @@
 import { type Adaptor, PlaceHolder } from "$lib/type"
 
-const Erc4626V1V1: Adaptor = {
-  name: "Erc4626V1V1",
+const Erc4626V1: Adaptor = {
+  name: "Erc4626V1",
   address: "",
   calls: [
     {
@@ -42,4 +42,4 @@ const Erc4626V1V1: Adaptor = {
     }
   ]
 }
-export default Erc4626V1V1;
+export default Erc4626V1;

--- a/src/lib/adaptors/Erc4626V1.ts
+++ b/src/lib/adaptors/Erc4626V1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const Erc4626V1V1: Adaptor = {
   name: "Erc4626V1V1",
@@ -11,12 +11,14 @@ const Erc4626V1V1: Adaptor = {
         {
           name: "erc4626_vault",
           label: "The address of the ERC4626 vault",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "assets",
           label: "The amount of assets to deposit",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -27,12 +29,14 @@ const Erc4626V1V1: Adaptor = {
         {
           name: "erc4626_vault",
           label: "The address of the ERC4626 vault",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "assets",
           label: "The amount of assets to deposit",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/FTokenV1.ts
+++ b/src/lib/adaptors/FTokenV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const FTokenV1: Adaptor = {
   name: "FTokenV1",
@@ -11,12 +11,14 @@ const FTokenV1: Adaptor = {
         {
           name: "f_token",
           label: "The address of the fToken to lend",
-          placeholder: "Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_to_deposit",
           label: "The amount of the fToken to lend",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/FeesAndReservesV1.ts
+++ b/src/lib/adaptors/FeesAndReservesV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const FeesAndReservesV1: Adaptor = {
   name: "FeesAndReservesV1",
@@ -11,7 +11,8 @@ const FeesAndReservesV1: Adaptor = {
         {
           name: "performance_fee",
           label: "New performance fee",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Empty,
+          type: "number"
         }
       ]
     },
@@ -22,7 +23,8 @@ const FeesAndReservesV1: Adaptor = {
         {
           name: "management_fee",
           label: "New management fee",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Empty,
+          type: "number"
         }
       ]
     },
@@ -33,7 +35,8 @@ const FeesAndReservesV1: Adaptor = {
         {
           name: "new_frequency",
           label: "New frequency",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Empty,
+          type: "number"
         }
       ]
     },
@@ -44,7 +47,8 @@ const FeesAndReservesV1: Adaptor = {
         {
           name: "new_max_gas",
           label: "New max gas",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Empty,
+          type: "number"
         }
       ]
     },
@@ -55,12 +59,14 @@ const FeesAndReservesV1: Adaptor = {
         {
           name: "management_fee",
           label: "Management fee",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Empty,
+          type: "number"
         },
         {
           name: "performance_fee",
           label: "Performance fee",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Empty,
+          type: "number"
         }
       ]
     },
@@ -71,7 +77,8 @@ const FeesAndReservesV1: Adaptor = {
         {
           name: "amount",
           label: "Amount",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -82,7 +89,8 @@ const FeesAndReservesV1: Adaptor = {
         {
           name: "amount",
           label: "Amount",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -93,7 +101,8 @@ const FeesAndReservesV1: Adaptor = {
         {
           name: "amount",
           label: "Amount",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/LegacyCellarV1.ts
+++ b/src/lib/adaptors/LegacyCellarV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const LegacyCellarV1: Adaptor = {
   name: "LegacyCellarV1",
@@ -11,17 +11,20 @@ const LegacyCellarV1: Adaptor = {
         {
           name: "cellar",
           label: "Cellar",
-          placeholder: "Cellar"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "assets",
           label: "Assets to deposit",
-          placeholder: "Assets"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "oracle",
           label: "Oracle",
-          placeholder: "Oracle"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         }
       ]
     },
@@ -32,17 +35,20 @@ const LegacyCellarV1: Adaptor = {
         {
           name: "cellar",
           label: "Cellar",
-          placeholder: "Cellar"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "assets",
           label: "Assets to withdraw",
-          placeholder: "Assets"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "oracle",
           label: "Oracle",
-          placeholder: "Oracle"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/MorphoAaveV2ATokenV1.ts
+++ b/src/lib/adaptors/MorphoAaveV2ATokenV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const MorphoAaveV2ATokenV1: Adaptor = {
   name: "MorphoAaveV2ATokenV1",
@@ -11,12 +11,14 @@ const MorphoAaveV2ATokenV1: Adaptor = {
         {
           name: "a_token",
           label: "Aave V2 aToken Contract Address",
-          placeholder: "0xaTokenAddress"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_to_deposit",
           label: "Amount of Asset to Deposit",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -27,12 +29,14 @@ const MorphoAaveV2ATokenV1: Adaptor = {
         {
           name: "a_token",
           label: "Aave V2 aToken Contract Address",
-          placeholder: "0xaTokenAddress"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_to_withdraw",
           label: "Amount of Asset to Withdraw",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/MorphoAaveV2DebtTokenV1.ts
+++ b/src/lib/adaptors/MorphoAaveV2DebtTokenV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const MorphoAaveV2DebtTokenV1: Adaptor = {
   name: "MorphoAaveV2DebtTokenV1",
@@ -11,12 +11,14 @@ const MorphoAaveV2DebtTokenV1: Adaptor = {
         {
           name: "a_token",
           label: "Aave V2 aToken Contract Address",
-          placeholder: "0xaTokenAddress"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_to_borrow",
           label: "Amount of Asset to Borrow",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -27,12 +29,14 @@ const MorphoAaveV2DebtTokenV1: Adaptor = {
         {
           name: "a_token",
           label: "Aave V2 aToken Contract Address",
-          placeholder: "0xaTokenAddress"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_to_repay",
           label: "Amount of Asset to Repay",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/MorphoAaveV3ATokenCollateralV1.ts
+++ b/src/lib/adaptors/MorphoAaveV3ATokenCollateralV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const MorphoAaveV3ATokenCollateralV1: Adaptor = {
   name: "MorphoAaveV3ATokenCollateralV1",
@@ -11,12 +11,14 @@ const MorphoAaveV3ATokenCollateralV1: Adaptor = {
         {
           name: "token_to_deposit",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xTokenAddress"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_to_deposit",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -27,12 +29,14 @@ const MorphoAaveV3ATokenCollateralV1: Adaptor = {
         {
           name: "token_to_withdraw",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xTokenAddress"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_to_withdraw",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/MorphoAaveV3ATokenP2pV1.ts
+++ b/src/lib/adaptors/MorphoAaveV3ATokenP2pV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const MorphoAaveV3ATokenP2pV1: Adaptor = {
   name: "MorphoAaveV3ATokenP2pV1",
@@ -11,17 +11,20 @@ const MorphoAaveV3ATokenP2pV1: Adaptor = {
         {
           name: "token_to_deposit",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xTokenAddress"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_to_deposit",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "max_iterations",
           label: "Max Iterations",
-          placeholder: "Max Iterations"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -32,17 +35,20 @@ const MorphoAaveV3ATokenP2pV1: Adaptor = {
         {
           name: "token_to_withdraw",
           label: "ERC-20 Token Contract Address",
-          placeholder: "0xTokenAddress"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_to_withdraw",
           label: "Amount of ERC-20 Asset",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "max_iterations",
           label: "Max Iterations",
-          placeholder: "Max Iterations"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/MorphoAaveV3DebtTokenV1.ts
+++ b/src/lib/adaptors/MorphoAaveV3DebtTokenV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const MorphoAaveV3DebtTokenV1: Adaptor = {
   name: "MorphoAaveV3DebtTokenV1",
@@ -11,17 +11,20 @@ const MorphoAaveV3DebtTokenV1: Adaptor = {
         {
           name: "underlying",
           label: "Underlying Asset",
-          placeholder: "Underlying Asset"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_to_borrow",
           label: "Amount to Borrow",
-          placeholder: "Amount to Borrow"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "max_iterations",
           label: "Max Iterations",
-          placeholder: "Max Iterations"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -32,12 +35,14 @@ const MorphoAaveV3DebtTokenV1: Adaptor = {
         {
           name: "token_to_repay",
           label: "Token to Repay",
-          placeholder: "Token to Repay"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_to_repay",
           label: "Amount to Repay",
-          placeholder: "Amount to Repay"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/MorphoBlueCollateralV1.ts
+++ b/src/lib/adaptors/MorphoBlueCollateralV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const MorphoBlueCollateralV1: Adaptor = {
   name: "MorphoBlueCollateralV1",
@@ -11,12 +11,14 @@ const MorphoBlueCollateralV1: Adaptor = {
         {
           name: "market",
           label: "Identifier of a Morpho Blue Market",
-          placeholder: "Market"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "collateral_to_deposit",
           label: "Amount of Collateral to Add",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -27,12 +29,14 @@ const MorphoBlueCollateralV1: Adaptor = {
         {
           name: "market",
           label: "Identifier of a Morpho Blue Market",
-          placeholder: "Market"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "collateral_amount",
           label: "Amount of Collateral to Remove",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/MorphoBlueDebtV1.ts
+++ b/src/lib/adaptors/MorphoBlueDebtV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const MorphoBlueDebtV1: Adaptor = {
   name: "MorphoBlueDebtV1",
@@ -11,12 +11,14 @@ const MorphoBlueDebtV1: Adaptor = {
         {
           name: "market",
           label: "Identifier of a Morpho Blue Market",
-          placeholder: "Market"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount_to_borrow",
           label: "Amount of Debt Token to Borrow",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -27,12 +29,14 @@ const MorphoBlueDebtV1: Adaptor = {
         {
           name: "market",
           label: "Identifier of a Morpho Blue Market",
-          placeholder: "Market"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "debt_token_repay_amount",
           label: "Amount of Debt Token to Repay",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/MorphoBlueSupplyV1.ts
+++ b/src/lib/adaptors/MorphoBlueSupplyV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList"
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const MorphoBlueSupplyV1: Adaptor = {
   name: "MorphoBlueSupplyV1",
@@ -11,12 +11,14 @@ const MorphoBlueSupplyV1: Adaptor = {
         {
           name: "market",
           label: "Identifier of a Morpho Blue Market",
-          placeholder: "Market"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "assets",
           label: "Amount of Loan Token to Lend",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -27,12 +29,14 @@ const MorphoBlueSupplyV1: Adaptor = {
         {
           name: "market",
           label: "Identifier of a Morpho Blue Market",
-          placeholder: "Market"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "assets",
           label: "Amount of Loan Token to Withdraw",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/OneInchV1.ts
+++ b/src/lib/adaptors/OneInchV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList";
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const OneInchV1: Adaptor = {
   name: "OneInchV1",
@@ -11,22 +11,26 @@ const OneInchV1: Adaptor = {
         {
           name: "token_in",
           label: "The Address of the Token to Swap From",
-          placeholder: "0xtoken"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "token_out",
           label: "The Address of the Token to Swap To",
-          placeholder: "0xtoken"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount",
           label: "The Amount to Swap",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "swap_call_data",
           label: "Swap Calldata",
-          placeholder: "Swap Calldata"
+          placeholder: PlaceHolder.ArrayOfNumber,
+          type: "array"
         }
       ]
     }

--- a/src/lib/adaptors/StakingV1.ts
+++ b/src/lib/adaptors/StakingV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList";
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const StakingV1: Adaptor = {
   name: "StakingV1",
@@ -11,17 +11,20 @@ const StakingV1: Adaptor = {
         {
           name: "amount",
           label: "Amount",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "min_amount_out",
           label: "Min Amount Out",
-          placeholder: "Min Amount Out"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "wildcard",
           label: "Wildcard Data",
-          placeholder: "Wildcard Data"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -32,12 +35,14 @@ const StakingV1: Adaptor = {
         {
           name: "amount",
           label: "Amount",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "wildcard",
           label: "Wildcard Data",
-          placeholder: "Wildcard Data"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -48,17 +53,20 @@ const StakingV1: Adaptor = {
         {
           name: "id",
           label: "Burn Request ID",
-          placeholder: "Burn Request ID"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "min_amount_out",
           label: "Min Amount Out",
-          placeholder: "Min Amount Out"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "wildcard",
           label: "Wildcard Data",
-          placeholder: "Wildcard Data"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -69,12 +77,14 @@ const StakingV1: Adaptor = {
         {
           name: "id",
           label: "Burn Request ID",
-          placeholder: "Burn Request ID"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "wildcard",
           label: "Wildcard Data",
-          placeholder: "Wildcard Data"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -85,17 +95,20 @@ const StakingV1: Adaptor = {
         {
           name: "amount",
           label: "Amount to Wrap",
-          placeholder: "Enter amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "min_amount_out",
           label: "Min Amount Out",
-          placeholder: "Enter minimum amount out"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "wildcard",
           label: "Wildcard Data",
-          placeholder: "Enter wildcard data"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -106,17 +119,20 @@ const StakingV1: Adaptor = {
         {
           name: "amount",
           label: "Amount to Unwrap",
-          placeholder: "Enter amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "min_amount_out",
           label: "Min Amount Out",
-          placeholder: "Enter minimum amount out"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "wildcard",
           label: "Wildcard Data",
-          placeholder: "Enter wildcard data"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -127,22 +143,26 @@ const StakingV1: Adaptor = {
         {
           name: "deposit_asset",
           label: "Deposit Asset Address",
-          placeholder: "Enter deposit asset address"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount",
-          placeholder: "Enter amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "min_amount_out",
           label: "Min Amount Out",
-          placeholder: "Enter minimum amount out"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "wildcard",
           label: "Wildcard Data",
-          placeholder: "Enter wildcard data"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -153,12 +173,14 @@ const StakingV1: Adaptor = {
         {
           name: "id",
           label: "Request ID",
-          placeholder: "Enter request ID"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "wildcard",
           label: "Wildcard Data",
-          placeholder: "Enter wildcard data"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/SwapWithUniswapV1.ts
+++ b/src/lib/adaptors/SwapWithUniswapV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList";
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const SwapWithUniswapV1: Adaptor = {
   name: "SwapWithUniswapV1",
@@ -11,17 +11,20 @@ const SwapWithUniswapV1: Adaptor = {
         {
           name: "path",
           label: "Address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.ArrayOfAddress,
+          type: "array"
         },
         {
           name: "amount",
           label: "Amount to Swap",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "amount_out_min",
           label: "Amount min",
-          placeholder: "Amount out min"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -32,22 +35,26 @@ const SwapWithUniswapV1: Adaptor = {
         {
           name: "path",
           label: "Address",
-          placeholder: "Address"
+          placeholder: PlaceHolder.ArrayOfAddress,
+          type: "array"
         },
         {
           name: "pool_fees",
           label: "Pool fees",
-          placeholder: "Pool fees"
+          placeholder: PlaceHolder.ArrayOfNumber,
+          type: "array"
         },
         {
           name: "amount",
           label: "Amount to Swap",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "amount_out_min",
           label: "Amount min",
-          placeholder: "Amount out min"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/UniswapV3V2.ts
+++ b/src/lib/adaptors/UniswapV3V2.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList";
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const UniswapV3V2: Adaptor = {
   name: "UniswapV3V2",
@@ -11,47 +11,56 @@ const UniswapV3V2: Adaptor = {
         {
           name: "token_0",
           label: "Token 0",
-          placeholder: "Enter Token 0 Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "token_1",
           label: "Token 1",
-          placeholder: "Enter Token 1 Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "pool_fee",
           label: "Pool Fee",
-          placeholder: "Enter Pool Fee"
+          placeholder: PlaceHolder.Empty,
+          type: "number"
         },
         {
           name: "amount_0",
           label: "Amount 0",
-          placeholder: "Enter Amount 0"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "amount_1",
           label: "Amount 1",
-          placeholder: "Enter Amount 1"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "min_0",
           label: "Min 0",
-          placeholder: "Enter Min 0"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "min_1",
           label: "Min 1",
-          placeholder: "Enter Min 1"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "tick_lower",
           label: "Tick Lower",
-          placeholder: "Enter Tick Lower"
+          placeholder: PlaceHolder.Empty,
+          type: "number"
         },
         {
           name: "tick_upper",
           label: "Tick Upper",
-          placeholder: "Enter Tick Upper"
+          placeholder: PlaceHolder.Empty,
+          type: "number"
         }
       ]
     },
@@ -62,17 +71,20 @@ const UniswapV3V2: Adaptor = {
         {
           name: "token_id",
           label: "Token ID",
-          placeholder: "Enter Token ID"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "min_0",
           label: "Min 0",
-          placeholder: "Enter Minimum 0"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "min_1",
           label: "Min 1",
-          placeholder: "Enter Minimum 1"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -83,27 +95,32 @@ const UniswapV3V2: Adaptor = {
         {
           name: "token_id",
           label: "Token ID",
-          placeholder: "Enter Token ID"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "amount_0",
           label: "Amount 0",
-          placeholder: "Enter Amount 0"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "amount_1",
           label: "Amount 1",
-          placeholder: "Enter Amount 1"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "min_0",
           label: "Min 0",
-          placeholder: "Enter Min 0"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "min_1",
           label: "Min 1",
-          placeholder: "Enter Min 1"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -114,27 +131,32 @@ const UniswapV3V2: Adaptor = {
         {
           name: "token_id",
           label: "Token ID",
-          placeholder: "Enter Token ID"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "liquidity",
           label: "Liquidity",
-          placeholder: "Enter Liquidity"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "min_0",
           label: "Min 0",
-          placeholder: "Enter Min 0"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "min_1",
           label: "Min 1",
-          placeholder: "Enter Min 1"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "take_fees",
           label: "Take Fees",
-          placeholder: "Check if you want to take fees"
+          placeholder: PlaceHolder.Empty,
+          type: "checkbox"
         }
       ]
     },
@@ -145,17 +167,20 @@ const UniswapV3V2: Adaptor = {
         {
           name: "token_id",
           label: "Token ID",
-          placeholder: "Enter Token ID"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "amount_0",
           label: "Amount 0",
-          placeholder: "Enter Amount 0"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "amount_1",
           label: "Amount 1",
-          placeholder: "Enter Amount 1"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -166,12 +191,14 @@ const UniswapV3V2: Adaptor = {
         {
           name: "token_0",
           label: "Token 0",
-          placeholder: "Enter Token 0 Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "token_1",
           label: "Token 1",
-          placeholder: "Enter Token 1 Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         }
       ]
     },
@@ -182,7 +209,8 @@ const UniswapV3V2: Adaptor = {
         {
           name: "token_id",
           label: "Token ID",
-          placeholder: "Enter Token ID"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -193,17 +221,20 @@ const UniswapV3V2: Adaptor = {
         {
           name: "token_id",
           label: "Token ID",
-          placeholder: "Enter Token ID"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "token_0",
           label: "Token 0",
-          placeholder: "Enter Token 0 Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "token_1",
           label: "Token 1",
-          placeholder: "Enter Token 1 Address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/VestingSimpleV2.ts
+++ b/src/lib/adaptors/VestingSimpleV2.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList";
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const VestingSimpleV2: Adaptor = {
   name: "VestingSimpleV2",
@@ -11,12 +11,14 @@ const VestingSimpleV2: Adaptor = {
         {
           name: "vesting_contract",
           label: "Vesting Contract Address",
-          placeholder: "Vesting contract address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount to Deposit",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -27,17 +29,20 @@ const VestingSimpleV2: Adaptor = {
         {
           name: "vesting_contract",
           label: "Vesting Contract Address",
-          placeholder: "Vesting contract address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "deposit_id",
           label: "Deposit ID",
-          placeholder: "Deposit ID"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount to Withdraw",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -48,12 +53,14 @@ const VestingSimpleV2: Adaptor = {
         {
           name: "vesting_contract",
           label: "Vesting Contract Address",
-          placeholder: "Vesting contract address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount to Withdraw",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         }
       ]
     },
@@ -64,7 +71,8 @@ const VestingSimpleV2: Adaptor = {
         {
           name: "vesting_contract",
           label: "Vesting Contract Address",
-          placeholder: "Vesting contract address"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         }
       ]
     }

--- a/src/lib/adaptors/ZeroXV1.ts
+++ b/src/lib/adaptors/ZeroXV1.ts
@@ -1,4 +1,4 @@
-import type { Adaptor } from "$lib/adaptorList";
+import { type Adaptor, PlaceHolder } from "$lib/type"
 
 const ZeroXV1: Adaptor = {
   name: "ZeroXV1",
@@ -11,22 +11,26 @@ const ZeroXV1: Adaptor = {
         {
           name: "token_in",
           label: "Token In (ERC-20 Contract Address)",
-          placeholder: "0xTokenInAddress"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "token_out",
           label: "Token Out (ERC-20 Contract Address)",
-          placeholder: "0xTokenOutAddress"
+          placeholder: PlaceHolder.Address,
+          type: "text"
         },
         {
           name: "amount",
           label: "Amount to Swap",
-          placeholder: "Amount"
+          placeholder: PlaceHolder.Text,
+          type: "text"
         },
         {
           name: "swap_call_data",
           label: "Swap Call Data",
-          placeholder: "Swap Call Data"
+          placeholder: PlaceHolder.ArrayOfNumber,
+          type: "array"
         }
       ]
     }

--- a/src/lib/administrativeFunctions.ts
+++ b/src/lib/administrativeFunctions.ts
@@ -1,4 +1,4 @@
-import { type CellarFunction, Functions } from "$lib/type"
+import { type CellarFunction, Functions, PlaceHolder } from "$lib/type"
 
 const AddPosition: CellarFunction = {
   function: Functions.AddPosition,
@@ -9,25 +9,25 @@ const AddPosition: CellarFunction = {
     {
       name: "index",
       label: "Index at which to add the position",
-      placeholder: "e.g 1",
+      placeholder: PlaceHolder.Empty,
       type: "number"
     },
     {
       name: "position_id",
       label: "The position's ID in the cellar registry",
-      placeholder: "e.g 1",
+      placeholder: PlaceHolder.Empty,
       type: "number"
     },
     {
       name: "configuration_data",
       label: "Data used to configure how the position behaves",
-      placeholder: "e.g [1,2,3]",
+      placeholder: PlaceHolder.ArrayOfNumber,
       type: "array"
     },
     {
       name: "in_debt_array",
       label: "Whether to add position in the debt array, or the credit array",
-      placeholder: "",
+      placeholder: PlaceHolder.Empty,
       type: "checkbox"
     }
   ]
@@ -42,13 +42,13 @@ const RemovePosition: CellarFunction = {
     {
       name: "index",
       label: "Index at which to remove the position",
-      placeholder: "e.g 1",
+      placeholder: PlaceHolder.Empty,
       type: "number"
     },
     {
       name: "in_debt_array",
       label: "Whether to add position in the debt array, or the credit array",
-      placeholder: "",
+      placeholder: PlaceHolder.Empty,
       type: "checkbox"
     },
   ]
@@ -63,7 +63,7 @@ const SetHoldingPosition: CellarFunction = {
     {
       name: "position_id",
       label: "ID (index) of the new holding position to use",
-      placeholder: "e.g 1",
+      placeholder: PlaceHolder.Empty,
       type: "number"
     }
   ]
@@ -78,7 +78,7 @@ const SetStrategistPayoutAddress: CellarFunction = {
     {
       name: "payout",
       label: "Payout address",
-      placeholder: "e.g 0x1111111111111111111111111111111111111111",
+      placeholder: PlaceHolder.Address,
       type: "text"
     }
   ]
@@ -93,19 +93,19 @@ const SwapPositions: CellarFunction = {
     {
       name: "index_1",
       label: "Index of the first position",
-      placeholder: "e.g 1",
+      placeholder: PlaceHolder.Empty,
       type: "number"
     },
     {
       name: "index_2",
       label: "Index of the second position",
-      placeholder: "e.g 2",
+      placeholder: PlaceHolder.Empty,
       type: "number"
     },
     {
       name: "in_debt_array",
       label: "Whether to switch positions in the debt array, or the credit array",
-      placeholder: "",
+      placeholder: PlaceHolder.Empty,
       type: "checkbox"
     },
   ]
@@ -120,7 +120,7 @@ const SetShareLockPeriod: CellarFunction = {
     {
       name: "new_lock",
       label: "New lock",
-      placeholder: "",
+      placeholder: PlaceHolder.Text,
       type: "text"
     }
   ]
@@ -145,11 +145,13 @@ const LiftShutdown: CellarFunction = {
 const RemoveAdaptorFromCatalogue: CellarFunction = {
   function: Functions.RemoveAdaptorFromCatalogue,
   action: "Remove",
+  info: "Allows callers to remove adaptors from this cellar's catalogue. " +
+    "Represents function removeAdaptorFromCatalogue(address adaptor)",
   fields: [
     {
       name: "adaptor",
       label: "Adaptor address",
-      placeholder: "adaptor",
+      placeholder: PlaceHolder.Address,
       type: "text"
     }
   ]
@@ -164,7 +166,7 @@ const RemovePositionFromCatalogue: CellarFunction = {
     {
       name: "position_id",
       label: "Position ID",
-      placeholder: "e.g 1",
+      placeholder: PlaceHolder.Empty,
       type: "number"
     }
   ]
@@ -179,7 +181,7 @@ const DecreaseShareSupplyCap: CellarFunction = {
     {
       name: "new_cap",
       label: "New share supply cap",
-      placeholder: "",
+      placeholder: PlaceHolder.Empty,
       type: "text"
     }
   ]
@@ -194,19 +196,19 @@ const SetAlternativeAssetData: CellarFunction = {
     {
       name: "alternative_asset",
       label: "The address of the alternative asset",
-      placeholder: "e.g 0x1111111111111111111111111111111111111111",
+      placeholder: PlaceHolder.Address,
       type: "text"
     },
     {
       name: "alternative_holding_position",
       label: "The holding position to direct alternative asset deposits to",
-      placeholder: "",
+      placeholder: PlaceHolder.Empty,
       type: "number"
     },
     {
       name: "alternative_asset_fee",
       label: "The fee to charge for depositing this alternative asset",
-      placeholder: "",
+      placeholder: PlaceHolder.Empty,
       type: "number"
     },
   ]
@@ -221,7 +223,7 @@ const DropAlternativeAssetData: CellarFunction = {
     {
       name: "alternative_asset",
       label: "The address of the alternative asset",
-      placeholder: "e.g 0x1111111111111111111111111111111111111111",
+      placeholder: PlaceHolder.Address,
       type: "text"
     }
   ]
@@ -236,7 +238,7 @@ const AddAdaptorToCatalogue: CellarFunction = {
     {
       name: "adaptor",
       label: "Adaptor address",
-      placeholder: "e.g 0x1111111111111111111111111111111111111111",
+      placeholder: PlaceHolder.Address,
       type: "text"
     }
   ]
@@ -251,7 +253,7 @@ const AddPositionToCatalogue: CellarFunction = {
     {
       name: "position_id",
       label: "Position ID",
-      placeholder: "e.g 1",
+      placeholder: PlaceHolder.Empty,
       type: "number"
     }
   ]
@@ -268,7 +270,7 @@ const SetRebalanceDeviation: CellarFunction = {
     {
       name: "new_deviation",
       label: "New deviation",
-      placeholder: "",
+      placeholder: PlaceHolder.Text,
       type: "text"
     }
   ]
@@ -283,7 +285,7 @@ const SetStrategistPlatformCut: CellarFunction = {
     {
       name: "new_cut",
       label: "The new strategist platform cut",
-      placeholder: "",
+      placeholder:  PlaceHolder.Empty,
       type: "number"
     }
   ]
@@ -298,7 +300,7 @@ const IncreaseShareSupplyCap: CellarFunction = {
     {
       name: "new_cap",
       label: "New cap",
-      placeholder: "",
+      placeholder:  PlaceHolder.Text,
       type: "text"
     }
   ]
@@ -313,13 +315,13 @@ const SetSharePriceOracle: CellarFunction = {
     {
       name: "registry_id",
       label: "Oracles registry ID",
-      placeholder: "e.g 1",
+      placeholder: PlaceHolder.Text,
       type: "text"
     },
     {
       name: "share_price_oracle",
       label: "Oracles contract address",
-      placeholder: "e.g 0x1111111111111111111111111111111111111111",
+      placeholder:  PlaceHolder.Address,
       type: "text"
     }
   ]
@@ -334,19 +336,19 @@ const CachePriceRouter: CellarFunction = {
     {
       name: "check_total_assets",
       label: "Whether to check the total assets of the cellar",
-      placeholder: "",
+      placeholder:  PlaceHolder.Empty,
       type: "checkbox"
     },
     {
       name: "allowable_range",
       label: "The allowable range of the cellar's total assets to deviate between old and new routers",
-      placeholder: "",
+      placeholder:  PlaceHolder.Empty,
       type: "number"
     },
     {
       name: "expected_price_router",
       label: "The expected price router address",
-      placeholder: "e.g 0x1111111111111111111111111111111111111111",
+      placeholder:  PlaceHolder.Address,
       type: "text"
     }
   ]

--- a/src/lib/type.ts
+++ b/src/lib/type.ts
@@ -60,6 +60,10 @@ export enum Functions {
   IncreaseShareSupplyCap = "IncreaseShareSupplyCap",
   CachePriceRouter = "CachePriceRouter"
 }
+export enum FlashLoan {
+  AaveV3DebtTokenV1FlashLoan = "AaveV3DebtTokenV1FlashLoan",
+  BalancerPoolV1FlashLoan = "BalancerPoolV1FlashLoan"
+}
 
 export interface Adaptor {
   name: string
@@ -71,8 +75,8 @@ export interface AdaptorCall {
   function: string
   action: string
   fields: Field[]
-
 }
+
 export interface Field {
   name: string
   label: string

--- a/src/lib/type.ts
+++ b/src/lib/type.ts
@@ -76,7 +76,7 @@ export interface AdaptorCall {
 export interface Field {
   name: string
   label: string
-  placeholder: string
+  placeholder: PlaceHolder | string
   type?: "number" | "checkbox" | "text" | "array"
 
 }

--- a/src/lib/type.ts
+++ b/src/lib/type.ts
@@ -92,7 +92,7 @@ export enum PlaceHolder {
   Text = "e.g 1",
   Address = "e.g 0x1111111111111111111111111111111111111111",
   ArrayOfString = 'e.g ["1","2","3"]',
-  ArrayOfAddress = 'e.g ["0x1111111111111111111111111111111111111111"]',
+  ArrayOfAddress = 'e.g., ["0x000...", "0x000..."]',
   ArrayOfNumber = "e.g [1,2,3]",
   Empty = ""
 }

--- a/src/lib/type.ts
+++ b/src/lib/type.ts
@@ -87,3 +87,12 @@ export interface CellarFunction {
   info?: string
   fields: Field[]
 }
+
+export enum PlaceHolder {
+  Text = "e.g 1",
+  Address = "e.g 0x1111111111111111111111111111111111111111",
+  ArrayOfString = 'e.g ["1","2","3"]',
+  ArrayOfAddress = 'e.g ["0x1111111111111111111111111111111111111111"]',
+  ArrayOfNumber = "e.g [1,2,3]",
+  Empty = ""
+}


### PR DESCRIPTION
- CallOnAdaptor frontend now supports different input types. (Done already for management calls, todo for flashloans)
- Removed predefined cellars selection
	As the users wont be changing current strategies we cannot use the predefined cellar system. To add it again it should be possible to create own cellar with name, address etc. This data should be saved to filesystem.
- Removing calls from the queue
	Made it possible to remove calls from queue one by one.

- Flashloans tab - btn names, flashloan inner calls display.
	Improve btn names and style to make them more understandable. Also now displaying flashloans inner calls in queue.